### PR TITLE
Rate-limit the login endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ All deployment settings live in `config/deployer.php` and are driven by `.env`.
 This tool can run arbitrary deploy commands, overwrite your web root, and restore databases. Treat the deployer instance as **privileged infrastructure**.
 
 - **Authentication is mandatory.** Every dashboard and action route is behind the `auth` middleware; there are no default credentials.
+- **Login is rate-limited.** After 5 failed attempts per email + IP, further attempts are locked out for 60 seconds (a `Lockout` event is dispatched).
 - **Destructive actions are POST + CSRF only** (deploy, restore, DB restore). Read-only downloads are GET.
 - **No shell injection.** All user-supplied names are validated against `^[A-Za-z0-9._-]+$` (no traversal, no metacharacters) and every shell argument is escaped via `escapeshellarg`.
 - **DB credentials never hit the process list** — `mysqldump`/`mysql` receive them through a temporary `0600` option file, not `-p<password>`.

--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -3,13 +3,28 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use Illuminate\Auth\Events\Lockout;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\RateLimiter;
+use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 use Illuminate\View\View;
 
 class AuthController extends Controller
 {
+    /**
+     * Failed attempts allowed per email + IP before lockout.
+     */
+    protected const MAX_ATTEMPTS = 5;
+
+    /**
+     * Lockout window in seconds once the limit is hit.
+     */
+    protected const DECAY_SECONDS = 60;
+
     /**
      * Show the login form.
      */
@@ -32,15 +47,46 @@ class AuthController extends Controller
             'password' => ['required', 'string'],
         ]);
 
+        $this->ensureIsNotRateLimited($request);
+
         if (Auth::attempt($credentials, $request->boolean('remember'))) {
+            RateLimiter::clear($this->throttleKey($request));
             $request->session()->regenerate();
 
             return redirect()->intended('/');
         }
 
+        RateLimiter::hit($this->throttleKey($request), self::DECAY_SECONDS);
+
         return back()
             ->withInput($request->only('email'))
             ->withErrors(['email' => 'These credentials do not match our records.']);
+    }
+
+    /**
+     * Block further attempts once too many have failed for this email + IP.
+     */
+    protected function ensureIsNotRateLimited(Request $request): void
+    {
+        if (! RateLimiter::tooManyAttempts($this->throttleKey($request), self::MAX_ATTEMPTS)) {
+            return;
+        }
+
+        Event::dispatch(new Lockout($request));
+
+        $seconds = RateLimiter::availableIn($this->throttleKey($request));
+
+        throw ValidationException::withMessages([
+            'email' => "Too many login attempts. Please try again in {$seconds} seconds.",
+        ]);
+    }
+
+    /**
+     * Rate-limit key scoped to the submitted email and client IP.
+     */
+    protected function throttleKey(Request $request): string
+    {
+        return Str::transliterate(Str::lower((string) $request->input('email')).'|'.$request->ip());
     }
 
     /**

--- a/tests/Feature/AuthTest.php
+++ b/tests/Feature/AuthTest.php
@@ -53,4 +53,30 @@ class AuthTest extends TestCase
         $this->actingAs($user)->post(route('logout'))->assertRedirect(route('login'));
         $this->assertGuest();
     }
+
+    public function test_login_is_rate_limited_after_repeated_failures(): void
+    {
+        $user = User::factory()->create(['password' => Hash::make('secret-password')]);
+
+        // Exhaust the allowed attempts with wrong passwords.
+        for ($i = 0; $i < 5; $i++) {
+            $this->post(route('login.attempt'), [
+                'email' => $user->email,
+                'password' => 'wrong-password',
+            ]);
+        }
+
+        // The next attempt is throttled — even the correct password is refused.
+        $response = $this->post(route('login.attempt'), [
+            'email' => $user->email,
+            'password' => 'secret-password',
+        ]);
+
+        $response->assertSessionHasErrors('email');
+        $this->assertStringContainsString(
+            'Too many login attempts',
+            session('errors')->first('email')
+        );
+        $this->assertGuest();
+    }
 }


### PR DESCRIPTION
## Summary
Brute-force protection for the deployer login. Since this dashboard can deploy code and overwrite databases, the single admin account is a high-value target.

- Throttles failed logins by **email + client IP**: 5 attempts, then a 60s lockout.
- Dispatches Laravel's `Lockout` event when the limit is hit.
- Clears the limiter on successful login.
- Follows the standard Laravel/Breeze `RateLimiter` pattern.

## Verification
- New `test_login_is_rate_limited_after_repeated_failures` confirms the 6th attempt is refused even with the correct password.
- Full suite: **20 tests pass**; `pint --test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)