### PR TITLE
Atomic zero-downtime release switching

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,9 +34,10 @@ ADMIN_PASSWORD=
 # Git repository to deploy (HTTPS with a token, or SSH with a configured key)
 GIT_REMOTE_URL=https://github.com/sohag-pro/laravel-deployer.git
 
-# Web-server document root. The live release is symlinked here on each deploy.
-# Absolute path, with a trailing slash.
-SERVE_DIR=/var/www/html/app/public_html/
+# Live-release symlink. SERVE_DIR itself becomes a symlink to the active
+# release and is swapped atomically on each deploy. Point your web server's
+# document root at SERVE_DIR/public. Absolute path, with a trailing slash.
+SERVE_DIR=/var/www/html/app/current/
 
 # Working directory where releases, shared storage, .env and DB dumps live.
 # Must be DIFFERENT from SERVE_DIR. Absolute path, with a trailing slash.

--- a/README.md
+++ b/README.md
@@ -46,10 +46,13 @@ BASE_DIR/                         # working area (NOT web-served)
 ├── database/                     # DB_DIR — timestamped .sql dumps
 └── .env                          # shared .env, symlinked into each release
 
-SERVE_DIR/  ──(symlinks)──▶  BASE_DIR/backups/<newest-release>/*
+SERVE_DIR  ──(symlink)──▶  BASE_DIR/backups/<newest-release>
    ▲
-   └── your web server's document root (e.g. nginx/apache points here)
+   └── SERVE_DIR is itself a symlink to the live release.
+       Point your web server's document root at SERVE_DIR/public.
 ```
+
+`SERVE_DIR` is a **single symlink** that points at the active release. Switching releases renames that symlink in one atomic operation (`rename(2)`), so a request never sees a missing or half-built release — that is what makes deploys and rollbacks zero-downtime.
 
 A single deploy run (`php artisan deploy`):
 
@@ -58,9 +61,13 @@ A single deploy run (`php artisan deploy`):
 3. Replaces the release's `storage/` with a symlink to the shared one, and links the shared `.env` in.
 4. Dumps the configured database to `DB_DIR/<db>-<timestamp>.sql` (if DB creds are set).
 5. Runs the build (`composer install && php artisan optimize:clear`) and your `AFTER_DEPLOY_COMMANDS`, plus an optional project `afterDeploy.sh`.
-6. Atomically switches `SERVE_DIR` to symlink the new release — this is the moment the new version goes live.
+6. Atomically re-points the `SERVE_DIR` symlink at the new release — this is the moment the new version goes live.
 
-**Rollback** just re-points `SERVE_DIR` at an older release directory. **Restore DB** pipes a chosen dump back into the database.
+**Rollback** atomically re-points `SERVE_DIR` at an older release. **Restore DB** pipes a chosen dump back into the database.
+
+> **Web-server root:** because `SERVE_DIR` resolves to a Laravel release, set your virtual host's document root to **`SERVE_DIR/public`** and enable symlink following (nginx does by default; Apache needs `Options +FollowSymLinks`).
+
+> **Upgrading from the old layout:** earlier versions symlinked each release file *into* `SERVE_DIR`. This version makes `SERVE_DIR` itself the symlink. On the first deploy/restore after upgrading, a legacy real `SERVE_DIR` is removed once and replaced with the symlink automatically — just confirm your document root points at `SERVE_DIR/public`.
 
 ---
 

--- a/app/Console/Commands/Deploy.php
+++ b/app/Console/Commands/Deploy.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use App\Support\Database;
+use App\Support\Releases;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
 use Symfony\Component\Process\Process;
@@ -46,7 +47,9 @@ class Deploy extends Command
                 return self::FAILURE;
             }
 
-            foreach ([$base_dir, $version_dir, $serve_dir, $storage_dir, $db_dir] as $dir) {
+            // Note: $serve_dir is intentionally not pre-created — it is managed
+            // as a symlink by Releases::switch().
+            foreach ([$base_dir, $version_dir, $storage_dir, $db_dir] as $dir) {
                 $this->ensureDirectory($dir);
             }
 
@@ -99,9 +102,8 @@ class Deploy extends Command
                 $this->exec(sprintf('cd %s && sh afterDeploy.sh', escapeshellarg($version_dir)));
             }
 
-            // Atomically switch the live serve directory to the new release.
-            $this->exec(sprintf('rm -rf %s', escapeshellarg($serve_dir).'/*'));
-            $this->exec(sprintf('ln -s %s %s', escapeshellarg($version_dir).'/*', escapeshellarg($serve_dir)));
+            // Atomically switch the live serve symlink to the new release.
+            Releases::switch($serve_dir, $version_dir);
 
             // First-deploy-only commands (e.g. key:generate).
             if ($run_one_time_commands && ! empty($one_time_commands)) {

--- a/app/Http/Controllers/DeploymentController.php
+++ b/app/Http/Controllers/DeploymentController.php
@@ -3,11 +3,11 @@
 namespace App\Http\Controllers;
 
 use App\Support\Database;
+use App\Support\Releases;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Log;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
-use Symfony\Component\Process\Process;
 use Throwable;
 
 class DeploymentController extends Controller
@@ -18,13 +18,8 @@ class DeploymentController extends Controller
         $base_dir = config('deployer.base_dir');
         $version_dir = $base_dir.config('deployer.version_dir');
         $db_dir = $base_dir.config('deployer.db_dir');
-        $live = null;
-
-        // Resolve the currently-served version from the symlink target.
-        if (file_exists($serve_dir)) {
-            $parts = @explode('/', (string) @readlink("$serve_dir/app"));
-            $live = $parts[count($parts) - 2] ?? null;
-        }
+        // The currently-served release is the target of the serve symlink.
+        $live = Releases::current($serve_dir);
 
         $this->ensureDirectory($base_dir);
         $this->ensureDirectory($version_dir);
@@ -67,14 +62,14 @@ class DeploymentController extends Controller
             return back()->with('error', 'Serve directory is not configured.');
         }
 
-        // Atomically re-point the serve directory at the chosen version.
-        Process::fromShellCommandline(
-            sprintf('rm -rf %s', escapeshellarg($serve_dir).'/*')
-        )->mustRun();
+        // Atomically re-point the serve symlink at the chosen release.
+        try {
+            Releases::switch($serve_dir, $version_dir);
+        } catch (Throwable $e) {
+            Log::error('Release restore failed', ['exception' => $e]);
 
-        Process::fromShellCommandline(
-            sprintf('ln -s %s %s', escapeshellarg($version_dir).'/*', escapeshellarg($serve_dir))
-        )->mustRun();
+            return back()->with('error', 'Restore failed: '.$e->getMessage());
+        }
 
         return back()->with('success', 'Restored successfully.');
     }

--- a/app/Support/Releases.php
+++ b/app/Support/Releases.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Support;
+
+use RuntimeException;
+
+/**
+ * Manages the "current release" symlink that the web server's document root
+ * follows. Switching releases is a single atomic rename of a symlink, so a
+ * request never sees a half-built or missing release (true zero-downtime).
+ *
+ * SERVE_DIR is itself a symlink that points at the active release directory.
+ * Point your web server's root at SERVE_DIR/public (it resolves through the
+ * symlink to the live release).
+ */
+class Releases
+{
+    /**
+     * Atomically point the serve path at $releaseDir.
+     *
+     * A temporary symlink is created next to the serve path and then renamed
+     * over it; rename(2) is atomic on the same filesystem and replaces an
+     * existing symlink in place. A legacy real directory at the serve path
+     * (from the pre-symlink model) is removed once, on first switch.
+     */
+    public static function switch(string $serveDir, string $releaseDir): void
+    {
+        $serveDir = rtrim($serveDir, '/');
+        $releaseDir = rtrim($releaseDir, '/');
+
+        if (! is_dir($releaseDir)) {
+            throw new RuntimeException("Release directory does not exist: {$releaseDir}");
+        }
+
+        // One-time migration: a real directory cannot be atomically replaced
+        // by rename(), so remove it before linking. Symlinks are replaced in
+        // place and need no special handling.
+        if (file_exists($serveDir) && ! is_link($serveDir) && is_dir($serveDir)) {
+            self::removeDirectory($serveDir);
+        }
+
+        $tmp = $serveDir.'__switch_tmp';
+        if (is_link($tmp) || file_exists($tmp)) {
+            @unlink($tmp);
+        }
+
+        if (! @symlink($releaseDir, $tmp)) {
+            throw new RuntimeException("Failed to create release symlink at {$tmp}");
+        }
+
+        if (! @rename($tmp, $serveDir)) {
+            @unlink($tmp);
+            throw new RuntimeException("Failed to switch serve directory to {$releaseDir}");
+        }
+    }
+
+    /**
+     * Name of the release the serve path currently points at, or null.
+     */
+    public static function current(string $serveDir): ?string
+    {
+        $serveDir = rtrim($serveDir, '/');
+
+        if (! is_link($serveDir)) {
+            return null;
+        }
+
+        $target = @readlink($serveDir);
+
+        return $target ? basename($target) : null;
+    }
+
+    /**
+     * Recursively delete a directory (used only for the one-time migration of
+     * a legacy non-symlink serve directory).
+     */
+    protected static function removeDirectory(string $dir): void
+    {
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($dir, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($items as $item) {
+            $item->isDir() && ! $item->isLink() ? @rmdir($item->getPathname()) : @unlink($item->getPathname());
+        }
+
+        @rmdir($dir);
+    }
+}

--- a/tests/Feature/ReleaseRestoreTest.php
+++ b/tests/Feature/ReleaseRestoreTest.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Support\Releases;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class ReleaseRestoreTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected string $base;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->base = sys_get_temp_dir().'/deployer_restore_'.uniqid();
+        mkdir($this->base.'/releases/2024-05-01', 0755, true);
+
+        config([
+            'deployer.base_dir' => $this->base,
+            'deployer.version_dir' => '/releases',
+            'deployer.serve_dir' => $this->base.'/current',
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        @exec('rm -rf '.escapeshellarg($this->base));
+        parent::tearDown();
+    }
+
+    public function test_restore_switches_the_serve_symlink(): void
+    {
+        $this->actingAs(User::factory()->create())
+            ->post('/restore/2024-05-01')
+            ->assertRedirect()
+            ->assertSessionHas('success');
+
+        $this->assertSame('2024-05-01', Releases::current($this->base.'/current'));
+    }
+
+    public function test_restore_reports_a_missing_release(): void
+    {
+        $this->actingAs(User::factory()->create())
+            ->post('/restore/2099-01-01')
+            ->assertSessionHas('error');
+    }
+}

--- a/tests/Unit/ReleasesTest.php
+++ b/tests/Unit/ReleasesTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\Releases;
+use PHPUnit\Framework\TestCase;
+
+class ReleasesTest extends TestCase
+{
+    protected string $base;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->base = sys_get_temp_dir().'/deployer_rel_'.uniqid();
+        mkdir($this->base, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        @exec('rm -rf '.escapeshellarg($this->base));
+        parent::tearDown();
+    }
+
+    public function test_switch_points_serve_at_release_and_current_reports_it(): void
+    {
+        $release = $this->base.'/releases/2024-01-01';
+        $serve = $this->base.'/current';
+        mkdir($release, 0755, true);
+
+        Releases::switch($serve, $release);
+
+        $this->assertTrue(is_link($serve));
+        $this->assertSame($release, readlink($serve));
+        $this->assertSame('2024-01-01', Releases::current($serve));
+    }
+
+    public function test_switch_replaces_previous_symlink_atomically(): void
+    {
+        $a = $this->base.'/releases/a';
+        $b = $this->base.'/releases/b';
+        $serve = $this->base.'/current';
+        mkdir($a, 0755, true);
+        mkdir($b, 0755, true);
+
+        Releases::switch($serve, $a);
+        $this->assertSame('a', Releases::current($serve));
+
+        Releases::switch($serve, $b);
+        $this->assertSame('b', Releases::current($serve));
+        $this->assertSame($b, readlink($serve));
+    }
+
+    public function test_switch_migrates_a_legacy_real_directory(): void
+    {
+        $release = $this->base.'/releases/v1';
+        $serve = $this->base.'/current';
+        mkdir($release, 0755, true);
+
+        // Legacy serve path: a real directory with stray contents.
+        mkdir($serve, 0755, true);
+        file_put_contents($serve.'/old.txt', 'x');
+
+        Releases::switch($serve, $release);
+
+        $this->assertTrue(is_link($serve));
+        $this->assertSame($release, readlink($serve));
+    }
+
+    public function test_current_returns_null_when_serve_is_not_a_symlink(): void
+    {
+        $this->assertNull(Releases::current($this->base.'/missing'));
+    }
+}


### PR DESCRIPTION
## Summary
Makes release switching truly zero-downtime. Previously deploy/restore did `rm -rf $SERVE_DIR/*` then re-created symlinks — a brief window where the serve directory was empty and requests 404/500'd.

Now **`SERVE_DIR` is itself a symlink** to the active release, swapped atomically via `rename(2)` (temp symlink renamed over the live one). A request never sees a missing or half-built release.

- New `App\Support\Releases::switch()/current()`, used by the Deploy command and the restore action.
- Restore catches switch failures → friendly flash instead of raw 500 (closes the error-handling gap).
- Legacy real `SERVE_DIR` directories are migrated to the symlink automatically on first switch.
- README + `.env.example` document the new model, web root (**`SERVE_DIR/public`**) and upgrade path.

## ⚠️ Breaking change
Set your web server's document root to `SERVE_DIR/public`. The first deploy/restore after upgrade converts a legacy real `SERVE_DIR` into the symlink automatically.

## Verification
- Unit tests for the swap helper (atomic replace, legacy-dir migration, current()).
- Feature test for the restore action.
- 26 tests pass; `pint --test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)