### PR TITLE
Prune old releases and database dumps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,12 @@ DB_DIR=database
 # AFTER_DEPLOY_COMMANDS is a comma-separated list.
 AFTER_DEPLOY_COMMANDS="php artisan config:cache,php artisan route:cache,php artisan view:cache"
 
+# Retention: how many releases / DB dumps to keep (0 = keep everything).
+# Older entries are pruned after a successful deploy; the live release is
+# never removed.
+KEEP_RELEASES=5
+KEEP_DB_DUMPS=10
+
 # ---------------------------------------------------------------------------
 # Database that the DEPLOYED application uses (dumped before each release,
 # and restorable from the dashboard). Leave blank to skip DB backups.

--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ All deployment settings live in `config/deployer.php` and are driven by `.env`.
 | `STORAGE_DIR` | Shared storage subfolder under `BASE_DIR` | `storage` |
 | `DB_DIR` | DB dumps subfolder under `BASE_DIR` | `database` |
 | `AFTER_DEPLOY_COMMANDS` | Comma-separated commands run in each release | `php artisan config:cache,php artisan route:cache` |
+| `KEEP_RELEASES` | Releases to retain; older pruned after deploy (0 = all) | `5` |
+| `KEEP_DB_DUMPS` | Database dumps to retain (0 = all) | `10` |
 | `DEPLOYER_DB_NAME` | Database of the **deployed app** to dump/restore | `myapp` |
 | `DEPLOYER_DB_USER` / `DEPLOYER_DB_PASSWORD` | Credentials for that database | |
 | `DEPLOYER_DB_HOST` / `DEPLOYER_DB_PORT` | Host/port for that database | `127.0.0.1` / `3306` |

--- a/app/Console/Commands/Deploy.php
+++ b/app/Console/Commands/Deploy.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands;
 
 use App\Support\Database;
 use App\Support\Releases;
+use App\Support\Retention;
 use Illuminate\Console\Command;
 use Illuminate\Support\Facades\Log;
 use Symfony\Component\Process\Process;
@@ -108,6 +109,14 @@ class Deploy extends Command
             // First-deploy-only commands (e.g. key:generate).
             if ($run_one_time_commands && ! empty($one_time_commands)) {
                 $this->exec(sprintf('cd %s && %s', escapeshellarg($version_dir), $one_time_commands));
+            }
+
+            // Prune old releases and dumps, never touching the live release.
+            $releasesRoot = $base_dir.config('deployer.version_dir');
+            $prunedReleases = Retention::pruneReleases($releasesRoot, (int) config('deployer.keep_releases'), $tag);
+            $prunedDumps = Retention::pruneDumps($db_dir, (int) config('deployer.keep_db_dumps'));
+            if ($prunedReleases || $prunedDumps) {
+                $this->info('Pruned '.count($prunedReleases).' release(s) and '.count($prunedDumps).' dump(s).');
             }
 
             $this->info("Deployed release {$tag}.");

--- a/app/Support/Retention.php
+++ b/app/Support/Retention.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace App\Support;
+
+/**
+ * Prunes old releases and database dumps so the deploy host does not slowly
+ * fill its disk. Newest entries are kept; the currently-live release is never
+ * removed regardless of the retention count.
+ */
+class Retention
+{
+    /**
+     * Keep the newest $keep release directories under $versionDir (plus the
+     * live release), deleting the rest along with any matching .zip archive.
+     *
+     * @return string[] names of the releases that were removed
+     */
+    public static function pruneReleases(string $versionDir, int $keep, ?string $liveName = null): array
+    {
+        if ($keep <= 0 || ! is_dir($versionDir)) {
+            return [];
+        }
+
+        $releases = [];
+        foreach (array_diff(scandir($versionDir) ?: [], ['.', '..']) as $entry) {
+            if (is_dir($versionDir.'/'.$entry)) {
+                $releases[] = $entry;
+            }
+        }
+
+        // Newest first; timestamped names sort chronologically.
+        rsort($releases);
+
+        $removed = [];
+        $kept = 0;
+        foreach ($releases as $release) {
+            if ($release === $liveName || $kept < $keep) {
+                $kept++;
+
+                continue;
+            }
+
+            self::delete($versionDir.'/'.$release);
+            @unlink($versionDir.'/'.$release.'.zip');
+            $removed[] = $release;
+        }
+
+        return $removed;
+    }
+
+    /**
+     * Keep the newest $keep files under $dbDir, deleting older dumps.
+     *
+     * @return string[] names of the dumps that were removed
+     */
+    public static function pruneDumps(string $dbDir, int $keep): array
+    {
+        if ($keep <= 0 || ! is_dir($dbDir)) {
+            return [];
+        }
+
+        $files = [];
+        foreach (array_diff(scandir($dbDir) ?: [], ['.', '..']) as $entry) {
+            if (is_file($dbDir.'/'.$entry)) {
+                $files[] = $entry;
+            }
+        }
+
+        rsort($files);
+
+        $removed = [];
+        foreach (array_slice($files, $keep) as $file) {
+            @unlink($dbDir.'/'.$file);
+            $removed[] = $file;
+        }
+
+        return $removed;
+    }
+
+    protected static function delete(string $path): void
+    {
+        if (is_link($path) || is_file($path)) {
+            @unlink($path);
+
+            return;
+        }
+
+        if (! is_dir($path)) {
+            return;
+        }
+
+        $items = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($path, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST
+        );
+
+        foreach ($items as $item) {
+            $item->isDir() && ! $item->isLink() ? @rmdir($item->getPathname()) : @unlink($item->getPathname());
+        }
+
+        @rmdir($path);
+    }
+}

--- a/config/deployer.php
+++ b/config/deployer.php
@@ -15,4 +15,9 @@ return [
     'db_password' => env('DEPLOYER_DB_PASSWORD'),
     'db_host' => env('DEPLOYER_DB_HOST', 'localhost'),
     'db_port' => env('DEPLOYER_DB_PORT', '3306'),
+
+    // Retention: how many releases and DB dumps to keep. Older entries are
+    // pruned after a successful deploy. Set to 0 to keep everything.
+    'keep_releases' => (int) env('KEEP_RELEASES', 5),
+    'keep_db_dumps' => (int) env('KEEP_DB_DUMPS', 10),
 ];

--- a/tests/Unit/RetentionTest.php
+++ b/tests/Unit/RetentionTest.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\Retention;
+use PHPUnit\Framework\TestCase;
+
+class RetentionTest extends TestCase
+{
+    protected string $base;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->base = sys_get_temp_dir().'/deployer_ret_'.uniqid();
+        mkdir($this->base, 0755, true);
+    }
+
+    protected function tearDown(): void
+    {
+        @exec('rm -rf '.escapeshellarg($this->base));
+        parent::tearDown();
+    }
+
+    public function test_prune_releases_keeps_newest_n_and_the_live_release(): void
+    {
+        $dir = $this->base.'/releases';
+        mkdir($dir, 0755, true);
+        foreach (['2024-01-01', '2024-01-02', '2024-01-03', '2024-01-04', '2024-01-05', '2024-01-06'] as $r) {
+            mkdir($dir.'/'.$r, 0755, true);
+            file_put_contents($dir.'/'.$r.'.zip', 'z');
+        }
+
+        // Keep 3 newest (04,05,06) plus the live release (01, the oldest).
+        $removed = Retention::pruneReleases($dir, 3, '2024-01-01');
+
+        sort($removed);
+        $this->assertSame(['2024-01-02', '2024-01-03'], $removed);
+        $this->assertDirectoryExists($dir.'/2024-01-01');
+        $this->assertDirectoryExists($dir.'/2024-01-04');
+        $this->assertDirectoryDoesNotExist($dir.'/2024-01-02');
+        $this->assertFileDoesNotExist($dir.'/2024-01-02.zip');
+    }
+
+    public function test_prune_releases_is_a_noop_when_keep_is_zero(): void
+    {
+        $dir = $this->base.'/releases';
+        mkdir($dir.'/a', 0755, true);
+        mkdir($dir.'/b', 0755, true);
+
+        $this->assertSame([], Retention::pruneReleases($dir, 0));
+        $this->assertDirectoryExists($dir.'/a');
+    }
+
+    public function test_prune_dumps_keeps_newest_n(): void
+    {
+        $dir = $this->base.'/db';
+        mkdir($dir, 0755, true);
+        foreach (['db-1.sql', 'db-2.sql', 'db-3.sql', 'db-4.sql'] as $f) {
+            file_put_contents($dir.'/'.$f, 'x');
+        }
+
+        $removed = Retention::pruneDumps($dir, 2);
+
+        sort($removed);
+        $this->assertSame(['db-1.sql', 'db-2.sql'], $removed);
+        $this->assertFileExists($dir.'/db-4.sql');
+        $this->assertFileDoesNotExist($dir.'/db-1.sql');
+    }
+}


### PR DESCRIPTION
## Summary
Adds disk retention so the deploy host doesn't slowly fill with old releases and dumps.

- After a successful deploy, releases beyond `KEEP_RELEASES` (default 5) and dumps beyond `KEEP_DB_DUMPS` (default 10) are pruned, newest first.
- The **live release is never removed**; a matching `<release>.zip` is deleted alongside its release.
- Set either to `0` to keep everything.
- New `App\Support\Retention`; config keys + `.env.example` + README updated.

## Verification
- Unit tests cover newest-N retention, live-release protection, zip cleanup, dump pruning, and the keep=0 no-op.
- 29 tests pass; `pint --test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)