### PR TITLE
Harden mysqldump and gzip database dumps

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -62,6 +62,9 @@ AFTER_DEPLOY_COMMANDS="php artisan config:cache,php artisan route:cache,php arti
 KEEP_RELEASES=5
 KEEP_DB_DUMPS=10
 
+# Gzip database dumps (written as .sql.gz, decompressed on restore).
+GZIP_DUMPS=true
+
 # ---------------------------------------------------------------------------
 # Database that the DEPLOYED application uses (dumped before each release,
 # and restorable from the dashboard). Leave blank to skip DB backups.

--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ All deployment settings live in `config/deployer.php` and are driven by `.env`.
 | `AFTER_DEPLOY_COMMANDS` | Comma-separated commands run in each release | `php artisan config:cache,php artisan route:cache` |
 | `KEEP_RELEASES` | Releases to retain; older pruned after deploy (0 = all) | `5` |
 | `KEEP_DB_DUMPS` | Database dumps to retain (0 = all) | `10` |
+| `GZIP_DUMPS` | Gzip dumps to `.sql.gz` (decompressed on restore) | `true` |
 | `DEPLOYER_DB_NAME` | Database of the **deployed app** to dump/restore | `myapp` |
 | `DEPLOYER_DB_USER` / `DEPLOYER_DB_PASSWORD` | Credentials for that database | |
 | `DEPLOYER_DB_HOST` / `DEPLOYER_DB_PORT` | Host/port for that database | `127.0.0.1` / `3306` |

--- a/app/Support/Database.php
+++ b/app/Support/Database.php
@@ -13,12 +13,18 @@ use Symfony\Component\Process\Process;
  */
 class Database
 {
+    /**
+     * mysqldump flags for a consistent, lock-light, complete backup.
+     */
+    protected const DUMP_FLAGS = '--single-transaction --quick --routines --triggers --no-tablespaces';
+
     public function __construct(
         protected ?string $name,
         protected ?string $user,
         protected ?string $password,
         protected string $host = '127.0.0.1',
         protected string $port = '3306',
+        protected bool $gzip = true,
     ) {}
 
     public static function fromConfig(): self
@@ -29,6 +35,7 @@ class Database
             config('deployer.db_password'),
             config('deployer.db_host', '127.0.0.1'),
             config('deployer.db_port', '3306'),
+            (bool) config('deployer.gzip_dumps', true),
         );
     }
 
@@ -38,15 +45,43 @@ class Database
     }
 
     /**
-     * Dump the configured database to $targetPath. Returns true on success.
+     * Final path a dump of $targetPath would be written to (adds .gz when
+     * gzip is enabled and the path is not already compressed).
      */
-    public function dump(string $targetPath): bool
+    public function dumpPath(string $targetPath): string
     {
-        return $this->run('mysqldump', $targetPath, append: true);
+        if ($this->gzip && ! str_ends_with($targetPath, '.gz')) {
+            return $targetPath.'.gz';
+        }
+
+        return $targetPath;
     }
 
     /**
-     * Restore the configured database from $sourcePath. Returns true on success.
+     * Dump the configured database to $targetPath (a .gz suffix is added when
+     * gzip is enabled). Returns true on success.
+     */
+    public function dump(string $targetPath): bool
+    {
+        $target = $this->dumpPath($targetPath);
+
+        $pipe = $this->gzip ? ' | gzip' : '';
+
+        return $this->run(function (string $optionFile) use ($pipe, $target) {
+            return sprintf(
+                'mysqldump --defaults-extra-file=%s %s %s%s > %s',
+                escapeshellarg($optionFile),
+                self::DUMP_FLAGS,
+                escapeshellarg($this->name),
+                $pipe,
+                escapeshellarg($target),
+            );
+        });
+    }
+
+    /**
+     * Restore the configured database from $sourcePath. Gzipped dumps
+     * (.gz) are decompressed on the fly. Returns true on success.
      */
     public function restore(string $sourcePath): bool
     {
@@ -54,13 +89,25 @@ class Database
             throw new RuntimeException("SQL file not found: {$sourcePath}");
         }
 
-        return $this->run('mysql', $sourcePath, append: false);
+        $reader = str_ends_with($sourcePath, '.gz')
+            ? sprintf('gunzip -c %s', escapeshellarg($sourcePath))
+            : sprintf('cat %s', escapeshellarg($sourcePath));
+
+        return $this->run(function (string $optionFile) use ($reader) {
+            return sprintf(
+                '%s | mysql --defaults-extra-file=%s %s',
+                $reader,
+                escapeshellarg($optionFile),
+                escapeshellarg($this->name),
+            );
+        });
     }
 
     /**
-     * Run a mysql-family client, streaming a file in or out via redirection.
+     * Build a shell command via $builder (given the temp option-file path),
+     * run it, and clean up the credentials file afterwards.
      */
-    protected function run(string $binary, string $file, bool $append): bool
+    protected function run(callable $builder): bool
     {
         if (! $this->isConfigured()) {
             throw new RuntimeException('Database credentials are not configured.');
@@ -69,19 +116,7 @@ class Database
         $optionFile = $this->writeOptionFile();
 
         try {
-            $redirect = $append ? '>' : '<';
-            // Credentials come from the option file; only trusted/validated
-            // values are interpolated and every one is shell-escaped.
-            $command = sprintf(
-                '%s --defaults-extra-file=%s %s %s %s',
-                $binary,
-                escapeshellarg($optionFile),
-                escapeshellarg($this->name),
-                $redirect,
-                escapeshellarg($file),
-            );
-
-            $process = Process::fromShellCommandline($command);
+            $process = Process::fromShellCommandline($builder($optionFile));
             $process->setTimeout(600);
             $process->run();
 

--- a/config/deployer.php
+++ b/config/deployer.php
@@ -20,4 +20,8 @@ return [
     // pruned after a successful deploy. Set to 0 to keep everything.
     'keep_releases' => (int) env('KEEP_RELEASES', 5),
     'keep_db_dumps' => (int) env('KEEP_DB_DUMPS', 10),
+
+    // Gzip database dumps (recommended). Dumps are written as .sql.gz and
+    // transparently decompressed on restore.
+    'gzip_dumps' => env('GZIP_DUMPS', true),
 ];

--- a/tests/Unit/DatabaseTest.php
+++ b/tests/Unit/DatabaseTest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\Database;
+use PHPUnit\Framework\TestCase;
+use RuntimeException;
+
+class DatabaseTest extends TestCase
+{
+    public function test_dump_path_appends_gz_when_gzip_enabled(): void
+    {
+        $db = new Database('app', 'root', 'secret', '127.0.0.1', '3306', gzip: true);
+
+        $this->assertSame('/db/app-2024.sql.gz', $db->dumpPath('/db/app-2024.sql'));
+        // Already compressed paths are left alone.
+        $this->assertSame('/db/app.sql.gz', $db->dumpPath('/db/app.sql.gz'));
+    }
+
+    public function test_dump_path_is_plain_when_gzip_disabled(): void
+    {
+        $db = new Database('app', 'root', 'secret', '127.0.0.1', '3306', gzip: false);
+
+        $this->assertSame('/db/app-2024.sql', $db->dumpPath('/db/app-2024.sql'));
+    }
+
+    public function test_is_configured_requires_name_and_user(): void
+    {
+        $this->assertTrue((new Database('app', 'root', 'secret'))->isConfigured());
+        $this->assertFalse((new Database(null, 'root', 'secret'))->isConfigured());
+        $this->assertFalse((new Database('app', null, 'secret'))->isConfigured());
+    }
+
+    public function test_restore_throws_for_missing_file(): void
+    {
+        $this->expectException(RuntimeException::class);
+
+        (new Database('app', 'root', 'secret'))->restore('/no/such/dump.sql');
+    }
+}


### PR DESCRIPTION
## Summary
Makes DB backups production-safe.

- `mysqldump` now uses `--single-transaction --quick --routines --triggers --no-tablespaces`: consistent, lock-light on InnoDB, includes routines/triggers, no `PROCESS` privilege needed.
- Dumps are **gzipped to `.sql.gz`** by default (`GZIP_DUMPS=true`) and transparently `gunzip`'d on restore.
- Credentials still come from a `0600` option file (never the process list).

## Verification
- Unit tests cover gzip path naming, `isConfigured()`, and the missing-file restore guard.
- 33 tests pass; `pint --test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)