### PR TITLE
Run deploys in the background with a live log

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -65,6 +65,11 @@ KEEP_DB_DUMPS=10
 # Gzip database dumps (written as .sql.gz, decompressed on restore).
 GZIP_DUMPS=true
 
+# Deploys run in a detached background process. PHP CLI binary used to launch
+# it, and how long (seconds) before a stuck "running" deploy is deemed stale.
+DEPLOYER_PHP_BINARY=php
+DEPLOYER_DEPLOY_TIMEOUT=1800
+
 # ---------------------------------------------------------------------------
 # Database that the DEPLOYED application uses (dumped before each release,
 # and restorable from the dashboard). Leave blank to skip DB backups.

--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ For production, point your web server at the deployer's own `public/` directory 
 ## Usage
 
 1. Sign in at `/` with the admin account.
-2. **Deploy** — click *Deploy*. A new release is cloned, built and switched in. The currently-live release is highlighted green.
+2. **Deploy** — click *Deploy*. The deploy runs in a **detached background process**, so the request returns immediately; the dashboard shows a live status badge and streams the deploy log (polled every 2s). The button is disabled while a deploy is in progress. The currently-live release is highlighted green.
 3. **Roll back** — in *Files*, click *Restore* on any previous release to make it live again.
 4. **Database** — every deploy leaves a dump in the list. *Download* it, or *Restore* to pipe it back into the database.
 
@@ -153,6 +153,8 @@ All deployment settings live in `config/deployer.php` and are driven by `.env`.
 | `KEEP_RELEASES` | Releases to retain; older pruned after deploy (0 = all) | `5` |
 | `KEEP_DB_DUMPS` | Database dumps to retain (0 = all) | `10` |
 | `GZIP_DUMPS` | Gzip dumps to `.sql.gz` (decompressed on restore) | `true` |
+| `DEPLOYER_PHP_BINARY` | PHP CLI used to launch the background deploy | `php` |
+| `DEPLOYER_DEPLOY_TIMEOUT` | Seconds before a stuck "running" deploy is stale | `1800` |
 | `DEPLOYER_DB_NAME` | Database of the **deployed app** to dump/restore | `myapp` |
 | `DEPLOYER_DB_USER` / `DEPLOYER_DB_PASSWORD` | Credentials for that database | |
 | `DEPLOYER_DB_HOST` / `DEPLOYER_DB_PORT` | Host/port for that database | `127.0.0.1` / `3306` |

--- a/app/Console/Commands/Deploy.php
+++ b/app/Console/Commands/Deploy.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use App\Support\Database;
+use App\Support\DeployState;
 use App\Support\Releases;
 use App\Support\Retention;
 use Illuminate\Console\Command;
@@ -31,8 +32,13 @@ class Deploy extends Command
      */
     public function handle(): int
     {
+        $tag = now()->format('Y-m-d__H_i_s');
+
+        // Reuse the run already marked by the dashboard, or start one when the
+        // command is invoked directly from the CLI.
+        $id = DeployState::running() ? (DeployState::status()['id'] ?? $tag) : DeployState::markStarted($tag);
+
         try {
-            $tag = now()->format('Y-m-d__H_i_s');
             $one_time_commands = config('deployer.one_time_commands');
             $commands = config('deployer.commands');
             $git_remote_url = config('deployer.git_remote_url');
@@ -44,6 +50,7 @@ class Deploy extends Command
 
             if (empty($git_remote_url)) {
                 $this->error('GIT_REMOTE_URL is not configured.');
+                DeployState::markFinished($id, false, 'GIT_REMOTE_URL is not configured.');
 
                 return self::FAILURE;
             }
@@ -120,11 +127,13 @@ class Deploy extends Command
             }
 
             $this->info("Deployed release {$tag}.");
+            DeployState::markFinished($id, true, "Deployed release {$tag}.");
 
             return self::SUCCESS;
         } catch (Throwable $th) {
             Log::error('Deployment failed', ['exception' => $th]);
             $this->error($th->getMessage());
+            DeployState::markFinished($id, false, $th->getMessage());
 
             return self::FAILURE;
         }

--- a/app/Http/Controllers/DeploymentController.php
+++ b/app/Http/Controllers/DeploymentController.php
@@ -3,9 +3,11 @@
 namespace App\Http\Controllers;
 
 use App\Support\Database;
+use App\Support\DeployLauncher;
+use App\Support\DeployState;
 use App\Support\Releases;
+use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
-use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Log;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Throwable;
@@ -27,8 +29,9 @@ class DeploymentController extends Controller
 
         $db_files = $this->listEntries($db_dir, directoriesOnly: false);
         $folders = $this->listEntries($version_dir, directoriesOnly: true);
+        $deploy = DeployState::status();
 
-        return view('home', compact('folders', 'live', 'db_files'));
+        return view('home', compact('folders', 'live', 'db_files', 'deploy'));
     }
 
     public function download(string $folder): BinaryFileResponse|RedirectResponse
@@ -110,15 +113,33 @@ class DeploymentController extends Controller
             : back()->with('error', 'Database restore failed. Check the logs.');
     }
 
-    public function deploy(): RedirectResponse
+    public function deploy(DeployLauncher $launcher): RedirectResponse
     {
-        $exitCode = Artisan::call('deploy');
-
-        if ($exitCode !== 0) {
-            return back()->with('error', 'Deploy failed. '.trim(Artisan::output()));
+        if (DeployState::running()) {
+            return back()->with('error', 'A deploy is already in progress.');
         }
 
-        return back()->with('success', 'Deployed successfully.');
+        // Mark running synchronously so the dashboard reflects it immediately,
+        // then launch the deploy in a detached background process.
+        DeployState::markStarted();
+        $launcher->launch();
+
+        return back()->with('success', 'Deploy started. Watch the log for progress.');
+    }
+
+    /**
+     * Live deploy status + log tail, polled by the dashboard.
+     */
+    public function deployStatus(): JsonResponse
+    {
+        $status = DeployState::status();
+
+        return response()->json([
+            'status' => $status['status'],
+            'message' => $status['message'],
+            'running' => DeployState::running(),
+            'log' => DeployState::logTail(),
+        ]);
     }
 
     /**

--- a/app/Support/DeployLauncher.php
+++ b/app/Support/DeployLauncher.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Support;
+
+use Symfony\Component\Process\Process;
+
+/**
+ * Launches `php artisan deploy` as a detached background process so the HTTP
+ * request returns immediately. Output is appended to the deploy log; nohup
+ * keeps the process alive after the request (and the parent shell) exits.
+ *
+ * Resolved from the container so tests can swap in a fake.
+ */
+class DeployLauncher
+{
+    public function launch(): void
+    {
+        $php = (string) config('deployer.php_binary', 'php');
+        $artisan = base_path('artisan');
+        $log = DeployState::logPath();
+
+        $command = sprintf(
+            'nohup %s %s deploy >> %s 2>&1 &',
+            escapeshellarg($php),
+            escapeshellarg($artisan),
+            escapeshellarg($log),
+        );
+
+        Process::fromShellCommandline($command)->run();
+    }
+}

--- a/app/Support/DeployState.php
+++ b/app/Support/DeployState.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Support;
+
+/**
+ * Tracks the state of the most recent (or in-progress) deploy in two files
+ * under BASE_DIR: a small JSON status file and a plain-text log. The deploy
+ * runs in a detached background process, so the dashboard reads these files
+ * to show live progress instead of blocking the HTTP request.
+ */
+class DeployState
+{
+    public const IDLE = 'idle';
+
+    public const RUNNING = 'running';
+
+    public const SUCCESS = 'success';
+
+    public const FAILED = 'failed';
+
+    protected static function dir(): string
+    {
+        return rtrim((string) config('deployer.base_dir'), '/');
+    }
+
+    public static function statusPath(): string
+    {
+        return self::dir().'/deploy-state.json';
+    }
+
+    public static function logPath(): string
+    {
+        return self::dir().'/deploy.log';
+    }
+
+    /**
+     * Current state as ['id', 'status', 'started_at', 'finished_at', 'message'].
+     */
+    public static function status(): array
+    {
+        $default = ['id' => null, 'status' => self::IDLE, 'started_at' => null, 'finished_at' => null, 'message' => null];
+
+        if (! is_file(self::statusPath())) {
+            return $default;
+        }
+
+        $data = json_decode((string) file_get_contents(self::statusPath()), true);
+
+        return is_array($data) ? array_merge($default, $data) : $default;
+    }
+
+    /**
+     * Whether a deploy is currently running and not yet stale.
+     */
+    public static function running(): bool
+    {
+        $status = self::status();
+
+        if (($status['status'] ?? null) !== self::RUNNING) {
+            return false;
+        }
+
+        $timeout = (int) config('deployer.deploy_timeout', 1800);
+        $startedAt = (int) ($status['started_at'] ?? 0);
+
+        return $timeout <= 0 || (time() - $startedAt) < $timeout;
+    }
+
+    /**
+     * Mark a new run as started and reset the log. Returns the run id.
+     */
+    public static function markStarted(?string $id = null): string
+    {
+        $id = $id ?: date('Y-m-d__H_i_s');
+
+        @mkdir(self::dir(), 0755, true);
+        file_put_contents(self::logPath(), '');
+        self::write([
+            'id' => $id,
+            'status' => self::RUNNING,
+            'started_at' => time(),
+            'finished_at' => null,
+            'message' => null,
+        ]);
+
+        return $id;
+    }
+
+    public static function markFinished(string $id, bool $ok, string $message = ''): void
+    {
+        self::write([
+            'id' => $id,
+            'status' => $ok ? self::SUCCESS : self::FAILED,
+            'started_at' => self::status()['started_at'] ?? null,
+            'finished_at' => time(),
+            'message' => $message,
+        ]);
+    }
+
+    /**
+     * Tail of the deploy log (last $bytes bytes).
+     */
+    public static function logTail(int $bytes = 40000): string
+    {
+        if (! is_file(self::logPath())) {
+            return '';
+        }
+
+        $size = filesize(self::logPath());
+        $offset = max(0, $size - $bytes);
+
+        return (string) file_get_contents(self::logPath(), false, null, $offset);
+    }
+
+    protected static function write(array $data): void
+    {
+        @mkdir(self::dir(), 0755, true);
+        file_put_contents(self::statusPath(), json_encode($data, JSON_PRETTY_PRINT));
+    }
+}

--- a/config/deployer.php
+++ b/config/deployer.php
@@ -24,4 +24,11 @@ return [
     // Gzip database dumps (recommended). Dumps are written as .sql.gz and
     // transparently decompressed on restore.
     'gzip_dumps' => env('GZIP_DUMPS', true),
+
+    // PHP CLI binary used to launch the background deploy process.
+    'php_binary' => env('DEPLOYER_PHP_BINARY', 'php'),
+
+    // A deploy still marked "running" after this many seconds is treated as
+    // stale, so a crashed deploy never blocks the dashboard permanently.
+    'deploy_timeout' => (int) env('DEPLOYER_DEPLOY_TIMEOUT', 1800),
 ];

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -22,16 +22,27 @@
         <div class="max-w-8xl mx-auto flex flex-col justify-center space-y-5 p-12 lg:flex-row lg:space-x-5 lg:space-y-0">
             <!-- Card 1 -->
             <div
-                class="flex h-full w-full flex-col items-center justify-between space-y-5 rounded-md border border-gray-100 bg-gray-200 bg-opacity-40 bg-clip-padding py-8 px-5 backdrop-blur-sm backdrop-filter">
-                <h2 class="pb-8 text-2xl font-medium text-gray-800">Deployment</h2>
+                class="flex h-full w-full flex-col items-center space-y-5 rounded-md border border-gray-100 bg-gray-200 bg-opacity-40 bg-clip-padding py-8 px-5 backdrop-blur-sm backdrop-filter">
+                <h2 class="text-2xl font-medium text-gray-800">Deployment</h2>
+
+                <div class="flex items-center gap-2 text-sm">
+                    <span class="text-gray-600">Status:</span>
+                    <span id="deploy-status-badge"
+                        class="rounded-md px-2 py-1 font-semibold"
+                        data-status="{{ $deploy['status'] }}">{{ ucfirst($deploy['status']) }}</span>
+                </div>
 
                 <form method="POST" action="{{ route('deploy') }}"
                     onsubmit="return confirm('Deploy the latest commit now?');">
                     @csrf
-                    <button type="submit" class="rounded-md bg-green-500 px-6 py-3 text-2xl font-semibold text-white">
+                    <button id="deploy-button" type="submit"
+                        class="rounded-md bg-green-500 px-6 py-3 text-2xl font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50">
                         Deploy
                     </button>
                 </form>
+
+                <pre id="deploy-log"
+                    class="hidden h-48 w-full overflow-auto rounded-md bg-gray-900 p-3 text-left text-xs text-green-200"></pre>
             </div>
 
             <!-- Card 2 -->
@@ -116,4 +127,54 @@
             </div>
         </div>
     </div>
+
+    <script>
+        (function () {
+            const statusUrl = @json(route('deploy.status'));
+            const badge = document.getElementById('deploy-status-badge');
+            const log = document.getElementById('deploy-log');
+            const button = document.getElementById('deploy-button');
+
+            const colors = {
+                running: 'bg-yellow-200 text-yellow-900',
+                success: 'bg-green-200 text-green-900',
+                failed: 'bg-red-200 text-red-900',
+                idle: 'bg-gray-200 text-gray-700',
+            };
+
+            function render(data) {
+                badge.textContent = data.status.charAt(0).toUpperCase() + data.status.slice(1);
+                badge.className = 'rounded-md px-2 py-1 font-semibold ' + (colors[data.status] || colors.idle);
+                button.disabled = data.running;
+
+                if (data.log && data.log.trim().length) {
+                    log.classList.remove('hidden');
+                    const atBottom = log.scrollHeight - log.clientHeight <= log.scrollTop + 4;
+                    log.textContent = data.log;
+                    if (atBottom) log.scrollTop = log.scrollHeight;
+                } else {
+                    log.classList.add('hidden');
+                }
+            }
+
+            let timer = null;
+            async function poll() {
+                try {
+                    const res = await fetch(statusUrl, { headers: { 'Accept': 'application/json' } });
+                    const data = await res.json();
+                    render(data);
+                    if (!data.running && timer) { clearInterval(timer); timer = null; }
+                } catch (e) { /* keep polling */ }
+            }
+
+            const initial = badge.dataset.status;
+            poll();
+            if (initial === 'running') {
+                timer = setInterval(poll, 2000);
+            }
+
+            // When a deploy is kicked off, the page reloads (form POST) with the
+            // status already "running", so polling starts on the fresh load.
+        })();
+    </script>
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -31,6 +31,9 @@ Route::middleware('auth')->group(function () {
     Route::get('download/{folder}', [DeploymentController::class, 'download'])->name('download');
     Route::get('download-db/{db_file}', [DeploymentController::class, 'downloadDb'])->name('downloadDb');
 
+    // Live deploy status (polled by the dashboard)
+    Route::get('deploy-status', [DeploymentController::class, 'deployStatus'])->name('deploy.status');
+
     // Destructive actions — POST + CSRF only
     Route::post('deploy', [DeploymentController::class, 'deploy'])->name('deploy');
     Route::post('restore/{folder}', [DeploymentController::class, 'restore'])->name('restore');

--- a/tests/Feature/AsyncDeployTest.php
+++ b/tests/Feature/AsyncDeployTest.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Support\DeployLauncher;
+use App\Support\DeployState;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AsyncDeployTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected string $base;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->base = sys_get_temp_dir().'/deployer_async_'.uniqid();
+        mkdir($this->base, 0755, true);
+        config(['deployer.base_dir' => $this->base, 'deployer.deploy_timeout' => 1800]);
+    }
+
+    protected function tearDown(): void
+    {
+        @exec('rm -rf '.escapeshellarg($this->base));
+        parent::tearDown();
+    }
+
+    protected function fakeLauncher(): object
+    {
+        $launcher = new class extends DeployLauncher
+        {
+            public bool $launched = false;
+
+            public function launch(): void
+            {
+                $this->launched = true;
+            }
+        };
+
+        $this->app->instance(DeployLauncher::class, $launcher);
+
+        return $launcher;
+    }
+
+    public function test_deploy_marks_running_and_launches_in_background(): void
+    {
+        $launcher = $this->fakeLauncher();
+
+        $this->actingAs(User::factory()->create())
+            ->post('/deploy')
+            ->assertRedirect()
+            ->assertSessionHas('success');
+
+        $this->assertTrue($launcher->launched);
+        $this->assertSame(DeployState::RUNNING, DeployState::status()['status']);
+    }
+
+    public function test_deploy_is_refused_while_one_is_running(): void
+    {
+        DeployState::markStarted('in-progress');
+        $launcher = $this->fakeLauncher();
+
+        $this->actingAs(User::factory()->create())
+            ->post('/deploy')
+            ->assertSessionHas('error');
+
+        $this->assertFalse($launcher->launched);
+    }
+
+    public function test_deploy_status_endpoint_returns_state_and_log(): void
+    {
+        DeployState::markStarted('run-1');
+
+        $this->actingAs(User::factory()->create())
+            ->getJson('/deploy-status')
+            ->assertOk()
+            ->assertJson(['status' => DeployState::RUNNING, 'running' => true]);
+    }
+
+    public function test_deploy_status_requires_authentication(): void
+    {
+        $this->get('/deploy-status')->assertRedirect(route('login'));
+    }
+}


### PR DESCRIPTION
## Summary
Turns deploy from a blocking request into an observable background job.

- Clicking **Deploy** marks the run `running`, launches `php artisan deploy` as a **detached `nohup` process**, and returns immediately — no more request timeouts on long deploys.
- The dashboard shows a live **status badge** (idle/running/success/failed) and **streams the deploy log**, polling `GET /deploy-status` every 2s. The Deploy button is disabled while running.
- **Concurrent deploys are refused**; a stuck "running" state expires after `DEPLOYER_DEPLOY_TIMEOUT` (default 1800s) so a crash never locks the UI.

## Design
- `App\Support\DeployState` — status JSON + log file under `BASE_DIR`.
- `App\Support\DeployLauncher` — detached launch, container-bound so tests inject a fake.
- The Deploy command records start/finish (and failure messages) and reuses a dashboard-initiated run id.

## Verification
- Feature tests: launches in background, refuses concurrent deploy, status endpoint JSON, auth required.
- 37 tests pass; `pint --test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)