### PR TITLE
Post-deploy health check with automatic rollback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -70,6 +70,12 @@ GZIP_DUMPS=true
 DEPLOYER_PHP_BINARY=php
 DEPLOYER_DEPLOY_TIMEOUT=1800
 
+# Post-deploy health check. If set, the new release is probed after it goes
+# live; if it never returns 2xx the previous release is restored automatically.
+DEPLOYER_HEALTH_URL=
+DEPLOYER_HEALTH_RETRIES=5
+DEPLOYER_HEALTH_DELAY=3
+
 # ---------------------------------------------------------------------------
 # Database that the DEPLOYED application uses (dumped before each release,
 # and restorable from the dashboard). Leave blank to skip DB backups.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ A single deploy run (`php artisan deploy`):
 5. Runs the build (`composer install && php artisan optimize:clear`) and your `AFTER_DEPLOY_COMMANDS`, plus an optional project `afterDeploy.sh`.
 6. Atomically re-points the `SERVE_DIR` symlink at the new release — this is the moment the new version goes live.
 
+If `DEPLOYER_HEALTH_URL` is set, the new release is probed after step 6; if it never returns `2xx`, the previous release is **automatically rolled back** and the deploy is marked failed.
+
 **Rollback** atomically re-points `SERVE_DIR` at an older release. **Restore DB** pipes a chosen dump back into the database.
 
 > **Web-server root:** because `SERVE_DIR` resolves to a Laravel release, set your virtual host's document root to **`SERVE_DIR/public`** and enable symlink following (nginx does by default; Apache needs `Options +FollowSymLinks`).
@@ -155,6 +157,8 @@ All deployment settings live in `config/deployer.php` and are driven by `.env`.
 | `GZIP_DUMPS` | Gzip dumps to `.sql.gz` (decompressed on restore) | `true` |
 | `DEPLOYER_PHP_BINARY` | PHP CLI used to launch the background deploy | `php` |
 | `DEPLOYER_DEPLOY_TIMEOUT` | Seconds before a stuck "running" deploy is stale | `1800` |
+| `DEPLOYER_HEALTH_URL` | Probe after switch; auto-rollback on failure (unset = off) | `https://app.example.com/up` |
+| `DEPLOYER_HEALTH_RETRIES` / `DEPLOYER_HEALTH_DELAY` | Probe attempts and seconds between them | `5` / `3` |
 | `DEPLOYER_DB_NAME` | Database of the **deployed app** to dump/restore | `myapp` |
 | `DEPLOYER_DB_USER` / `DEPLOYER_DB_PASSWORD` | Credentials for that database | |
 | `DEPLOYER_DB_HOST` / `DEPLOYER_DB_PORT` | Host/port for that database | `127.0.0.1` / `3306` |

--- a/app/Console/Commands/Deploy.php
+++ b/app/Console/Commands/Deploy.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands;
 
 use App\Support\Database;
 use App\Support\DeployState;
+use App\Support\HealthCheck;
 use App\Support\Releases;
 use App\Support\Retention;
 use Illuminate\Console\Command;
@@ -110,7 +111,10 @@ class Deploy extends Command
                 $this->exec(sprintf('cd %s && sh afterDeploy.sh', escapeshellarg($version_dir)));
             }
 
-            // Atomically switch the live serve symlink to the new release.
+            // Remember the live release so we can roll back if the new one is
+            // unhealthy, then atomically switch to the new release.
+            $releasesRoot = $base_dir.config('deployer.version_dir');
+            $previousLive = Releases::current($serve_dir);
             Releases::switch($serve_dir, $version_dir);
 
             // First-deploy-only commands (e.g. key:generate).
@@ -118,8 +122,32 @@ class Deploy extends Command
                 $this->exec(sprintf('cd %s && %s', escapeshellarg($version_dir), $one_time_commands));
             }
 
+            // Post-deploy health check; roll back to the previous release on
+            // failure so a broken build never stays live.
+            $healthUrl = (string) config('deployer.health_url');
+            if ($healthUrl !== '') {
+                $this->info("Health check: {$healthUrl}");
+                $healthy = HealthCheck::passes(
+                    $healthUrl,
+                    (int) config('deployer.health_retries', 5),
+                    (int) config('deployer.health_delay', 3),
+                );
+
+                if (! $healthy) {
+                    $rolledBack = $this->rollback($serve_dir, $releasesRoot, $previousLive);
+                    $message = $rolledBack
+                        ? "Health check failed; rolled back to {$previousLive}."
+                        : 'Health check failed; no previous release to roll back to.';
+                    $this->error($message);
+                    DeployState::markFinished($id, false, $message);
+
+                    return self::FAILURE;
+                }
+
+                $this->info('Health check passed.');
+            }
+
             // Prune old releases and dumps, never touching the live release.
-            $releasesRoot = $base_dir.config('deployer.version_dir');
             $prunedReleases = Retention::pruneReleases($releasesRoot, (int) config('deployer.keep_releases'), $tag);
             $prunedDumps = Retention::pruneDumps($db_dir, (int) config('deployer.keep_db_dumps'));
             if ($prunedReleases || $prunedDumps) {
@@ -144,6 +172,27 @@ class Deploy extends Command
         if (! file_exists($path)) {
             mkdir($path, 0755, true);
         }
+    }
+
+    /**
+     * Re-point the serve symlink at a previous release. Returns false when
+     * there is no previous release to roll back to.
+     */
+    protected function rollback(string $serveDir, string $releasesRoot, ?string $previousLive): bool
+    {
+        if (empty($previousLive)) {
+            return false;
+        }
+
+        $previousDir = rtrim($releasesRoot, '/').'/'.$previousLive;
+
+        if (! is_dir($previousDir)) {
+            return false;
+        }
+
+        Releases::switch($serveDir, $previousDir);
+
+        return true;
     }
 
     /**

--- a/app/Support/HealthCheck.php
+++ b/app/Support/HealthCheck.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Facades\Http;
+use Throwable;
+
+/**
+ * Probes a URL after a release goes live so a broken deploy can be rolled
+ * back automatically. A 2xx response counts as healthy; the probe is retried
+ * to allow the application a moment to warm up.
+ */
+class HealthCheck
+{
+    public static function passes(string $url, int $retries = 5, int $delaySeconds = 3): bool
+    {
+        $retries = max(1, $retries);
+
+        for ($attempt = 0; $attempt < $retries; $attempt++) {
+            try {
+                if (Http::timeout(10)->get($url)->successful()) {
+                    return true;
+                }
+            } catch (Throwable) {
+                // Connection refused / DNS / timeout — treat as not yet healthy.
+            }
+
+            if ($attempt < $retries - 1 && $delaySeconds > 0) {
+                sleep($delaySeconds);
+            }
+        }
+
+        return false;
+    }
+}

--- a/config/deployer.php
+++ b/config/deployer.php
@@ -31,4 +31,10 @@ return [
     // A deploy still marked "running" after this many seconds is treated as
     // stale, so a crashed deploy never blocks the dashboard permanently.
     'deploy_timeout' => (int) env('DEPLOYER_DEPLOY_TIMEOUT', 1800),
+
+    // Post-deploy health check. If set, the new release is probed after it
+    // goes live; on failure the previous release is restored automatically.
+    'health_url' => env('DEPLOYER_HEALTH_URL'),
+    'health_retries' => (int) env('DEPLOYER_HEALTH_RETRIES', 5),
+    'health_delay' => (int) env('DEPLOYER_HEALTH_DELAY', 3),
 ];

--- a/tests/Feature/HealthCheckTest.php
+++ b/tests/Feature/HealthCheckTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Support\HealthCheck;
+use Illuminate\Http\Client\ConnectionException;
+use Illuminate\Support\Facades\Http;
+use Tests\TestCase;
+
+class HealthCheckTest extends TestCase
+{
+    public function test_it_passes_on_a_2xx_response(): void
+    {
+        Http::fake(['*' => Http::response('ok', 200)]);
+
+        $this->assertTrue(HealthCheck::passes('https://app.test/up', retries: 1, delaySeconds: 0));
+    }
+
+    public function test_it_fails_after_retries_on_error_responses(): void
+    {
+        Http::fake(['*' => Http::response('boom', 500)]);
+
+        $this->assertFalse(HealthCheck::passes('https://app.test/up', retries: 3, delaySeconds: 0));
+        Http::assertSentCount(3);
+    }
+
+    public function test_it_fails_when_the_host_is_unreachable(): void
+    {
+        Http::fake(function () {
+            throw new ConnectionException('refused');
+        });
+
+        $this->assertFalse(HealthCheck::passes('https://app.test/up', retries: 2, delaySeconds: 0));
+    }
+}


### PR DESCRIPTION
## Summary
A broken build should never stay live. When `DEPLOYER_HEALTH_URL` is set, the deploy probes the new release after it goes live; if it never returns `2xx` (after `DEPLOYER_HEALTH_RETRIES` attempts, `DEPLOYER_HEALTH_DELAY`s apart), the serve symlink is re-pointed at the **previous release** and the deploy is marked failed.

- New `App\Support\HealthCheck` — retried 2xx probe via the HTTP client.
- Deploy command captures the previous release before switching and rolls back on failure.
- No-op when no health URL is configured (behaviour unchanged).

## Verification
- Feature tests: passes on 2xx, fails after N retries on 5xx, fails on unreachable host (faked HTTP).
- 40 tests pass; `pint --test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)