### PR TITLE
Deploy a chosen branch, tag or commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ For production, point your web server at the deployer's own `public/` directory 
 ## Usage
 
 1. Sign in at `/` with the admin account.
-2. **Deploy** — click *Deploy*. The deploy runs in a **detached background process**, so the request returns immediately; the dashboard shows a live status badge and streams the deploy log (polled every 2s). The button is disabled while a deploy is in progress. The currently-live release is highlighted green.
+2. **Deploy** — optionally enter a **branch, tag or commit** (blank = the repository's default branch), then click *Deploy*. The deploy runs in a **detached background process**, so the request returns immediately; the dashboard shows a live status badge and streams the deploy log (polled every 2s). The button is disabled while a deploy is in progress. The currently-live release is highlighted green.
 3. **Roll back** — in *Files*, click *Restore* on any previous release to make it live again.
 4. **Database** — every deploy leaves a dump in the list. *Download* it, or *Restore* to pipe it back into the database.
 

--- a/app/Console/Commands/Deploy.php
+++ b/app/Console/Commands/Deploy.php
@@ -19,7 +19,7 @@ class Deploy extends Command
      *
      * @var string
      */
-    protected $signature = 'deploy';
+    protected $signature = 'deploy {--ref= : Branch, tag or commit to deploy (defaults to the repository default branch)}';
 
     /**
      * The console command description.
@@ -62,8 +62,23 @@ class Deploy extends Command
                 $this->ensureDirectory($dir);
             }
 
+            // Resolve the git ref to deploy (defaults to the remote's HEAD).
+            $ref = trim((string) $this->option('ref'));
+            if ($ref !== '' && ! self::isValidRef($ref)) {
+                $this->error("Invalid git ref: {$ref}");
+                DeployState::markFinished($id, false, "Invalid git ref: {$ref}");
+
+                return self::FAILURE;
+            }
+
             // Clone the repository into the new release directory.
             $this->exec(sprintf('git clone %s %s', escapeshellarg($git_remote_url), escapeshellarg($version_dir)));
+
+            // Check out the requested ref (branch, tag or commit).
+            if ($ref !== '') {
+                $this->info("Deploying ref: {$ref}");
+                $this->exec(sprintf('git -C %s checkout --quiet %s', escapeshellarg($version_dir), escapeshellarg($ref)));
+            }
 
             // Seed the shared storage directory on the very first deploy only.
             if (count(scandir($storage_dir)) === 2) {
@@ -172,6 +187,19 @@ class Deploy extends Command
         if (! file_exists($path)) {
             mkdir($path, 0755, true);
         }
+    }
+
+    /**
+     * Allow only safe git ref characters (branch/tag/commit), no shell
+     * metacharacters, spaces, leading dashes or '..'.
+     */
+    public static function isValidRef(string $ref): bool
+    {
+        return $ref !== ''
+            && strlen($ref) <= 255
+            && ! str_starts_with($ref, '-')
+            && ! str_contains($ref, '..')
+            && (bool) preg_match('#^[A-Za-z0-9._/-]+$#', $ref);
     }
 
     /**

--- a/app/Http/Controllers/DeploymentController.php
+++ b/app/Http/Controllers/DeploymentController.php
@@ -2,12 +2,14 @@
 
 namespace App\Http\Controllers;
 
+use App\Console\Commands\Deploy as DeployCommand;
 use App\Support\Database;
 use App\Support\DeployLauncher;
 use App\Support\DeployState;
 use App\Support\Releases;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Log;
 use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Throwable;
@@ -113,16 +115,21 @@ class DeploymentController extends Controller
             : back()->with('error', 'Database restore failed. Check the logs.');
     }
 
-    public function deploy(DeployLauncher $launcher): RedirectResponse
+    public function deploy(Request $request, DeployLauncher $launcher): RedirectResponse
     {
         if (DeployState::running()) {
             return back()->with('error', 'A deploy is already in progress.');
         }
 
+        $ref = trim((string) $request->input('ref', ''));
+        if ($ref !== '' && ! DeployCommand::isValidRef($ref)) {
+            return back()->with('error', 'Invalid branch, tag or commit reference.');
+        }
+
         // Mark running synchronously so the dashboard reflects it immediately,
         // then launch the deploy in a detached background process.
         DeployState::markStarted();
-        $launcher->launch();
+        $launcher->launch($ref);
 
         return back()->with('success', 'Deploy started. Watch the log for progress.');
     }

--- a/app/Support/DeployLauncher.php
+++ b/app/Support/DeployLauncher.php
@@ -13,16 +13,21 @@ use Symfony\Component\Process\Process;
  */
 class DeployLauncher
 {
-    public function launch(): void
+    public function launch(?string $ref = null): void
     {
         $php = (string) config('deployer.php_binary', 'php');
         $artisan = base_path('artisan');
         $log = DeployState::logPath();
 
+        $refArg = ($ref !== null && $ref !== '')
+            ? ' --ref='.escapeshellarg($ref)
+            : '';
+
         $command = sprintf(
-            'nohup %s %s deploy >> %s 2>&1 &',
+            'nohup %s %s deploy%s >> %s 2>&1 &',
             escapeshellarg($php),
             escapeshellarg($artisan),
+            $refArg,
             escapeshellarg($log),
         );
 

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -32,9 +32,14 @@
                         data-status="{{ $deploy['status'] }}">{{ ucfirst($deploy['status']) }}</span>
                 </div>
 
-                <form method="POST" action="{{ route('deploy') }}"
-                    onsubmit="return confirm('Deploy the latest commit now?');">
+                <form method="POST" action="{{ route('deploy') }}" class="flex flex-col items-center gap-3"
+                    onsubmit="return confirm('Deploy now?');">
                     @csrf
+                    <input type="text" name="ref" value="{{ old('ref') }}"
+                        placeholder="branch / tag / commit (optional)"
+                        pattern="[A-Za-z0-9._/\-]+"
+                        title="Leave blank for the default branch"
+                        class="w-64 rounded-md border border-gray-300 px-3 py-2 text-center text-sm focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500">
                     <button id="deploy-button" type="submit"
                         class="rounded-md bg-green-500 px-6 py-3 text-2xl font-semibold text-white disabled:cursor-not-allowed disabled:opacity-50">
                         Deploy

--- a/tests/Feature/AsyncDeployTest.php
+++ b/tests/Feature/AsyncDeployTest.php
@@ -34,9 +34,12 @@ class AsyncDeployTest extends TestCase
         {
             public bool $launched = false;
 
-            public function launch(): void
+            public ?string $ref = null;
+
+            public function launch(?string $ref = null): void
             {
                 $this->launched = true;
+                $this->ref = $ref;
             }
         };
 
@@ -56,6 +59,29 @@ class AsyncDeployTest extends TestCase
 
         $this->assertTrue($launcher->launched);
         $this->assertSame(DeployState::RUNNING, DeployState::status()['status']);
+    }
+
+    public function test_deploy_passes_a_valid_ref_to_the_launcher(): void
+    {
+        $launcher = $this->fakeLauncher();
+
+        $this->actingAs(User::factory()->create())
+            ->post('/deploy', ['ref' => 'release/v1.2.3'])
+            ->assertSessionHas('success');
+
+        $this->assertTrue($launcher->launched);
+        $this->assertSame('release/v1.2.3', $launcher->ref);
+    }
+
+    public function test_deploy_rejects_an_invalid_ref(): void
+    {
+        $launcher = $this->fakeLauncher();
+
+        $this->actingAs(User::factory()->create())
+            ->post('/deploy', ['ref' => 'foo;rm -rf /'])
+            ->assertSessionHas('error');
+
+        $this->assertFalse($launcher->launched);
     }
 
     public function test_deploy_is_refused_while_one_is_running(): void

--- a/tests/Unit/DeployRefTest.php
+++ b/tests/Unit/DeployRefTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Console\Commands\Deploy;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\TestCase;
+
+class DeployRefTest extends TestCase
+{
+    #[DataProvider('validRefs')]
+    public function test_accepts_valid_refs(string $ref): void
+    {
+        $this->assertTrue(Deploy::isValidRef($ref));
+    }
+
+    public static function validRefs(): array
+    {
+        return [
+            ['main'],
+            ['release/v1.2.3'],
+            ['v1.0.0'],
+            ['feature/new-ui'],
+            ['9f2a1c4'],
+        ];
+    }
+
+    #[DataProvider('invalidRefs')]
+    public function test_rejects_unsafe_refs(string $ref): void
+    {
+        $this->assertFalse(Deploy::isValidRef($ref));
+    }
+
+    public static function invalidRefs(): array
+    {
+        return [
+            'empty' => [''],
+            'semicolon' => ['foo;rm'],
+            'space' => ['foo bar'],
+            'backtick' => ['foo`id`'],
+            'dotdot' => ['foo..bar'],
+            'leading dash' => ['--upload-pack=x'],
+            'dollar' => ['foo$(id)'],
+        ];
+    }
+}


### PR DESCRIPTION
## Summary
Adds an optional git ref to deploys.

- The deploy form takes a **branch / tag / commit** (blank = default branch). When set, the release is `git checkout`'d at that ref after cloning.
- Refs are validated in **both** the controller and the command — only `[A-Za-z0-9._/-]`, no spaces, leading dashes or `..` — and passed to the background process via `--ref` (shell-escaped).

## Verification
- Unit tests for `Deploy::isValidRef()` (valid + injection attempts).
- Feature tests: valid ref reaches the launcher; invalid ref rejected with an error and not launched.
- 54 tests pass; `pint --test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)