### PR TITLE
Security headers and optional HTTPS enforcement

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -76,6 +76,10 @@ DEPLOYER_HEALTH_URL=
 DEPLOYER_HEALTH_RETRIES=5
 DEPLOYER_HEALTH_DELAY=3
 
+# Redirect insecure requests to HTTPS and send HSTS (recommended in
+# production). Ignored on the local environment.
+DEPLOYER_FORCE_HTTPS=false
+
 # ---------------------------------------------------------------------------
 # Database that the DEPLOYED application uses (dumped before each release,
 # and restorable from the dashboard). Leave blank to skip DB backups.

--- a/README.md
+++ b/README.md
@@ -177,7 +177,8 @@ This tool can run arbitrary deploy commands, overwrite your web root, and restor
 - **Destructive actions are POST + CSRF only** (deploy, restore, DB restore). Read-only downloads are GET.
 - **No shell injection.** All user-supplied names are validated against `^[A-Za-z0-9._-]+$` (no traversal, no metacharacters) and every shell argument is escaped via `escapeshellarg`.
 - **DB credentials never hit the process list** — `mysqldump`/`mysql` receive them through a temporary `0600` option file, not `-p<password>`.
-- **Run it behind HTTPS** and, ideally, restrict access by IP / VPN / basic-auth at the web-server layer.
+- **Run it behind HTTPS** and, ideally, restrict access by IP / VPN / basic-auth at the web-server layer. Set `DEPLOYER_FORCE_HTTPS=true` to redirect insecure requests and emit HSTS.
+- **Security headers** (`X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy`, `Permissions-Policy`) are sent on every response.
 - Set `APP_DEBUG=false` and `APP_ENV=production` in production.
 - The OS user running the deployer needs write access to `BASE_DIR` and `SERVE_DIR`; scope it tightly.
 

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -6,6 +6,7 @@ use App\Http\Middleware\Authenticate;
 use App\Http\Middleware\EncryptCookies;
 use App\Http\Middleware\PreventRequestsDuringMaintenance;
 use App\Http\Middleware\RedirectIfAuthenticated;
+use App\Http\Middleware\SecurityHeaders;
 use App\Http\Middleware\TrimStrings;
 use App\Http\Middleware\TrustProxies;
 use App\Http\Middleware\ValidateSignature;
@@ -58,6 +59,7 @@ class Kernel extends HttpKernel
             ShareErrorsFromSession::class,
             VerifyCsrfToken::class,
             SubstituteBindings::class,
+            SecurityHeaders::class,
         ],
 
         'api' => [

--- a/app/Http/Middleware/SecurityHeaders.php
+++ b/app/Http/Middleware/SecurityHeaders.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+/**
+ * Adds baseline security response headers and, when DEPLOYER_FORCE_HTTPS is
+ * enabled, redirects insecure requests to HTTPS. This dashboard controls
+ * deploys, so it should never be served over plain HTTP in production.
+ */
+class SecurityHeaders
+{
+    public function handle(Request $request, Closure $next): Response
+    {
+        $forceHttps = (bool) config('deployer.force_https');
+
+        if ($forceHttps && ! $request->secure() && ! app()->environment('local')) {
+            return redirect()->secure($request->getRequestUri());
+        }
+
+        $response = $next($request);
+
+        $response->headers->set('X-Frame-Options', 'DENY');
+        $response->headers->set('X-Content-Type-Options', 'nosniff');
+        $response->headers->set('Referrer-Policy', 'same-origin');
+        $response->headers->set('X-Permitted-Cross-Domain-Policies', 'none');
+        $response->headers->set('Permissions-Policy', 'geolocation=(), microphone=(), camera=()');
+
+        if ($request->secure() || $forceHttps) {
+            $response->headers->set('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+        }
+
+        return $response;
+    }
+}

--- a/config/deployer.php
+++ b/config/deployer.php
@@ -37,4 +37,8 @@ return [
     'health_url' => env('DEPLOYER_HEALTH_URL'),
     'health_retries' => (int) env('DEPLOYER_HEALTH_RETRIES', 5),
     'health_delay' => (int) env('DEPLOYER_HEALTH_DELAY', 3),
+
+    // Redirect insecure requests to HTTPS and emit HSTS. Strongly recommended
+    // in production; ignored on the local environment.
+    'force_https' => (bool) env('DEPLOYER_FORCE_HTTPS', false),
 ];

--- a/tests/Feature/SecurityHeadersTest.php
+++ b/tests/Feature/SecurityHeadersTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Tests\Feature;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class SecurityHeadersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_security_headers_are_present_on_responses(): void
+    {
+        $response = $this->get(route('login'));
+
+        $response->assertHeader('X-Frame-Options', 'DENY');
+        $response->assertHeader('X-Content-Type-Options', 'nosniff');
+        $response->assertHeader('Referrer-Policy', 'same-origin');
+        $response->assertHeader('Permissions-Policy');
+    }
+
+    public function test_insecure_requests_are_redirected_when_force_https_is_on(): void
+    {
+        config(['deployer.force_https' => true]);
+
+        $response = $this->get('http://localhost/login');
+
+        $response->assertStatus(302);
+        $this->assertStringStartsWith('https://', $response->headers->get('Location'));
+    }
+
+    public function test_https_is_not_forced_by_default(): void
+    {
+        $this->get('http://localhost/login')->assertOk();
+    }
+}


### PR DESCRIPTION
## Summary
Hardens HTTP responses for a tool that controls deploys.

- New `SecurityHeaders` middleware on the web group sends `X-Frame-Options: DENY`, `X-Content-Type-Options: nosniff`, `Referrer-Policy: same-origin`, `X-Permitted-Cross-Domain-Policies: none` and a restrictive `Permissions-Policy` on every response.
- `DEPLOYER_FORCE_HTTPS=true` redirects insecure requests to HTTPS (skipped on local) and emits HSTS.

## Verification
- Feature tests: header presence, forced-HTTPS redirect, and default (no redirect).
- 57 tests pass; `pint --test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)