### PR TITLE
Optional TOTP two-factor authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ This tool can run arbitrary deploy commands, overwrite your web root, and restor
 
 - **Authentication is mandatory.** Every dashboard and action route is behind the `auth` middleware; there are no default credentials.
 - **Login is rate-limited.** After 5 failed attempts per email + IP, further attempts are locked out for 60 seconds (a `Lockout` event is dispatched).
+- **Optional TOTP two-factor.** Enable it from the dashboard (*Two-factor*); logins then require an authenticator code, with one-time recovery codes as a fallback.
 - **Destructive actions are POST + CSRF only** (deploy, restore, DB restore). Read-only downloads are GET.
 - **No shell injection.** All user-supplied names are validated against `^[A-Za-z0-9._-]+$` (no traversal, no metacharacters) and every shell argument is escaped via `escapeshellarg`.
 - **DB credentials never hit the process list** — `mysqldump`/`mysql` receive them through a temporary `0600` option file, not `-p<password>`.

--- a/app/Http/Controllers/Auth/AuthController.php
+++ b/app/Http/Controllers/Auth/AuthController.php
@@ -3,11 +3,14 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
+use App\Models\User;
+use App\Support\Totp;
 use Illuminate\Auth\Events\Lockout;
 use Illuminate\Http\RedirectResponse;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Event;
+use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\RateLimiter;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
@@ -49,18 +52,78 @@ class AuthController extends Controller
 
         $this->ensureIsNotRateLimited($request);
 
-        if (Auth::attempt($credentials, $request->boolean('remember'))) {
-            RateLimiter::clear($this->throttleKey($request));
-            $request->session()->regenerate();
+        $user = User::where('email', $credentials['email'])->first();
 
-            return redirect()->intended('/');
+        if (! $user || ! Hash::check($credentials['password'], $user->password)) {
+            RateLimiter::hit($this->throttleKey($request), self::DECAY_SECONDS);
+
+            return back()
+                ->withInput($request->only('email'))
+                ->withErrors(['email' => 'These credentials do not match our records.']);
         }
 
-        RateLimiter::hit($this->throttleKey($request), self::DECAY_SECONDS);
+        RateLimiter::clear($this->throttleKey($request));
 
-        return back()
-            ->withInput($request->only('email'))
-            ->withErrors(['email' => 'These credentials do not match our records.']);
+        // When 2FA is enabled, defer login until the code is verified.
+        if ($user->hasTwoFactorEnabled()) {
+            $request->session()->put('auth.2fa.user_id', $user->id);
+            $request->session()->put('auth.2fa.remember', $request->boolean('remember'));
+
+            return redirect()->route('two-factor.challenge');
+        }
+
+        Auth::login($user, $request->boolean('remember'));
+        $request->session()->regenerate();
+
+        return redirect()->intended('/');
+    }
+
+    /**
+     * Show the two-factor challenge after a correct password.
+     */
+    public function showChallenge(Request $request): View|RedirectResponse
+    {
+        if (! $request->session()->has('auth.2fa.user_id')) {
+            return redirect()->route('login');
+        }
+
+        return view('auth.two-factor-challenge');
+    }
+
+    /**
+     * Verify a TOTP code or recovery code and complete login.
+     */
+    public function challenge(Request $request): RedirectResponse
+    {
+        $userId = $request->session()->get('auth.2fa.user_id');
+        if (! $userId) {
+            return redirect()->route('login');
+        }
+
+        $this->ensureIsNotRateLimited($request);
+
+        $user = User::find($userId);
+        $code = trim((string) $request->input('code'));
+        $recovery = trim((string) $request->input('recovery_code'));
+
+        $passed = ($code !== '' && Totp::verify((string) $user->two_factor_secret, $code))
+            || ($recovery !== '' && $user->useRecoveryCode($recovery));
+
+        if (! $passed) {
+            RateLimiter::hit($this->throttleKey($request), self::DECAY_SECONDS);
+
+            return back()->withErrors(['code' => 'The provided two-factor code was invalid.']);
+        }
+
+        RateLimiter::clear($this->throttleKey($request));
+
+        $remember = (bool) $request->session()->pull('auth.2fa.remember', false);
+        $request->session()->forget('auth.2fa.user_id');
+
+        Auth::login($user, $remember);
+        $request->session()->regenerate();
+
+        return redirect()->intended('/');
     }
 
     /**

--- a/app/Http/Controllers/Auth/TwoFactorController.php
+++ b/app/Http/Controllers/Auth/TwoFactorController.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Http\Controllers\Auth;
+
+use App\Http\Controllers\Controller;
+use App\Support\Totp;
+use Illuminate\Http\RedirectResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Str;
+use Illuminate\View\View;
+
+class TwoFactorController extends Controller
+{
+    /**
+     * Two-factor settings page.
+     */
+    public function index(Request $request): View
+    {
+        $user = $request->user();
+
+        $uri = null;
+        if ($user->two_factor_secret && ! $user->hasTwoFactorEnabled()) {
+            $uri = Totp::uri($user->two_factor_secret, $user->email, config('app.name'));
+        }
+
+        return view('auth.two-factor', [
+            'user' => $user,
+            'provisioningUri' => $uri,
+            'recoveryCodes' => session('recovery_codes'),
+        ]);
+    }
+
+    /**
+     * Generate a secret and begin enrollment (not yet confirmed).
+     */
+    public function enable(Request $request): RedirectResponse
+    {
+        $user = $request->user();
+
+        $user->forceFill([
+            'two_factor_secret' => Totp::generateSecret(),
+            'two_factor_recovery_codes' => null,
+            'two_factor_confirmed_at' => null,
+        ])->save();
+
+        return redirect()->route('two-factor.index')
+            ->with('success', 'Scan the QR code with your authenticator app, then confirm a code to finish.');
+    }
+
+    /**
+     * Confirm enrollment by verifying a code; issues recovery codes.
+     */
+    public function confirm(Request $request): RedirectResponse
+    {
+        $request->validate(['code' => ['required', 'string']]);
+        $user = $request->user();
+
+        if (! $user->two_factor_secret || ! Totp::verify($user->two_factor_secret, $request->input('code'))) {
+            return back()->withErrors(['code' => 'The provided code was invalid.']);
+        }
+
+        $codes = collect(range(1, 8))
+            ->map(fn () => Str::lower(Str::random(5).'-'.Str::random(5)))
+            ->all();
+
+        $user->forceFill([
+            'two_factor_recovery_codes' => $codes,
+            'two_factor_confirmed_at' => now(),
+        ])->save();
+
+        return redirect()->route('two-factor.index')
+            ->with('success', 'Two-factor authentication is now enabled. Save your recovery codes.')
+            ->with('recovery_codes', $codes);
+    }
+
+    /**
+     * Disable two-factor authentication.
+     */
+    public function disable(Request $request): RedirectResponse
+    {
+        $request->user()->forceFill([
+            'two_factor_secret' => null,
+            'two_factor_recovery_codes' => null,
+            'two_factor_confirmed_at' => null,
+        ])->save();
+
+        return redirect()->route('two-factor.index')->with('success', 'Two-factor authentication disabled.');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -31,6 +31,8 @@ class User extends Authenticatable
     protected $hidden = [
         'password',
         'remember_token',
+        'two_factor_secret',
+        'two_factor_recovery_codes',
     ];
 
     /**
@@ -40,5 +42,34 @@ class User extends Authenticatable
      */
     protected $casts = [
         'email_verified_at' => 'datetime',
+        'two_factor_confirmed_at' => 'datetime',
+        'two_factor_secret' => 'encrypted',
+        'two_factor_recovery_codes' => 'encrypted:array',
     ];
+
+    /**
+     * Whether the user has confirmed two-factor authentication enabled.
+     */
+    public function hasTwoFactorEnabled(): bool
+    {
+        return ! empty($this->two_factor_secret) && ! is_null($this->two_factor_confirmed_at);
+    }
+
+    /**
+     * Consume a one-time recovery code; returns true if it was valid.
+     */
+    public function useRecoveryCode(string $code): bool
+    {
+        $codes = $this->two_factor_recovery_codes ?? [];
+        $code = trim($code);
+
+        if (! in_array($code, $codes, true)) {
+            return false;
+        }
+
+        $this->two_factor_recovery_codes = array_values(array_diff($codes, [$code]));
+        $this->save();
+
+        return true;
+    }
 }

--- a/app/Support/Totp.php
+++ b/app/Support/Totp.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace App\Support;
+
+/**
+ * Minimal RFC 6238 TOTP implementation (SHA-1, 6 digits, 30s step) — enough
+ * to enroll and verify an authenticator app without pulling in a dependency.
+ */
+class Totp
+{
+    protected const ALPHABET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+
+    protected const DIGITS = 6;
+
+    protected const PERIOD = 30;
+
+    /**
+     * Generate a random Base32 secret (default 160 bits / 32 chars).
+     */
+    public static function generateSecret(int $length = 32): string
+    {
+        $secret = '';
+        for ($i = 0; $i < $length; $i++) {
+            $secret .= self::ALPHABET[random_int(0, 31)];
+        }
+
+        return $secret;
+    }
+
+    /**
+     * Build the otpauth:// provisioning URI for QR codes / manual entry.
+     */
+    public static function uri(string $secret, string $label, string $issuer): string
+    {
+        return sprintf(
+            'otpauth://totp/%s?secret=%s&issuer=%s&algorithm=SHA1&digits=%d&period=%d',
+            rawurlencode($issuer.':'.$label),
+            $secret,
+            rawurlencode($issuer),
+            self::DIGITS,
+            self::PERIOD,
+        );
+    }
+
+    /**
+     * Verify a code against the secret, allowing +/- $window time steps for
+     * clock drift.
+     */
+    public static function verify(string $secret, string $code, int $window = 1): bool
+    {
+        $code = preg_replace('/\D/', '', $code);
+        if (strlen((string) $code) !== self::DIGITS) {
+            return false;
+        }
+
+        $counter = (int) floor(time() / self::PERIOD);
+
+        for ($i = -$window; $i <= $window; $i++) {
+            if (hash_equals(self::code($secret, $counter + $i), $code)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Current TOTP code for a secret (useful for tooling and tests).
+     */
+    public static function now(string $secret): string
+    {
+        return self::code($secret, (int) floor(time() / self::PERIOD));
+    }
+
+    /**
+     * Compute the HOTP value for a given counter.
+     */
+    protected static function code(string $secret, int $counter): string
+    {
+        $key = self::base32Decode($secret);
+        $binCounter = pack('N*', 0).pack('N*', $counter);
+
+        $hash = hash_hmac('sha1', $binCounter, $key, true);
+        $offset = ord($hash[strlen($hash) - 1]) & 0x0F;
+
+        $value = (
+            ((ord($hash[$offset]) & 0x7F) << 24) |
+            ((ord($hash[$offset + 1]) & 0xFF) << 16) |
+            ((ord($hash[$offset + 2]) & 0xFF) << 8) |
+            (ord($hash[$offset + 3]) & 0xFF)
+        ) % (10 ** self::DIGITS);
+
+        return str_pad((string) $value, self::DIGITS, '0', STR_PAD_LEFT);
+    }
+
+    protected static function base32Decode(string $secret): string
+    {
+        $secret = rtrim(strtoupper($secret), '=');
+        $buffer = 0;
+        $bitsLeft = 0;
+        $output = '';
+
+        foreach (str_split($secret) as $char) {
+            $index = strpos(self::ALPHABET, $char);
+            if ($index === false) {
+                continue;
+            }
+
+            $buffer = ($buffer << 5) | $index;
+            $bitsLeft += 5;
+
+            if ($bitsLeft >= 8) {
+                $bitsLeft -= 8;
+                $output .= chr(($buffer >> $bitsLeft) & 0xFF);
+            }
+        }
+
+        return $output;
+    }
+}

--- a/database/migrations/2024_01_01_000000_add_two_factor_columns_to_users_table.php
+++ b/database/migrations/2024_01_01_000000_add_two_factor_columns_to_users_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->text('two_factor_secret')->nullable();
+            $table->text('two_factor_recovery_codes')->nullable();
+            $table->timestamp('two_factor_confirmed_at')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropColumn([
+                'two_factor_secret',
+                'two_factor_recovery_codes',
+                'two_factor_confirmed_at',
+            ]);
+        });
+    }
+};

--- a/resources/views/auth/two-factor-challenge.blade.php
+++ b/resources/views/auth/two-factor-challenge.blade.php
@@ -1,0 +1,36 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="min-h-screen flex items-center justify-center bg-gray-100 px-4">
+        <div class="w-full max-w-md rounded-lg bg-white p-8 shadow">
+            <h1 class="mb-1 text-center text-2xl font-semibold text-gray-800">Two-factor authentication</h1>
+            <p class="mb-6 text-center text-sm text-gray-500">Enter the code from your authenticator app.</p>
+
+            @if ($errors->any())
+                <div class="mb-4 rounded-md bg-red-100 px-4 py-3 text-sm text-red-700">{{ $errors->first() }}</div>
+            @endif
+
+            <form method="POST" action="{{ route('two-factor.verify') }}" class="space-y-4">
+                @csrf
+
+                <div>
+                    <label for="code" class="mb-1 block text-sm font-medium text-gray-700">Authentication code</label>
+                    <input id="code" name="code" type="text" inputmode="numeric" autocomplete="one-time-code" autofocus
+                        class="w-full rounded-md border border-gray-300 px-3 py-2 tracking-widest focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500">
+                </div>
+
+                <details class="text-sm text-gray-600">
+                    <summary class="cursor-pointer">Use a recovery code instead</summary>
+                    <input name="recovery_code" type="text"
+                        class="mt-2 w-full rounded-md border border-gray-300 px-3 py-2 focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500"
+                        placeholder="xxxxx-xxxxx">
+                </details>
+
+                <button type="submit"
+                    class="w-full rounded-md bg-indigo-600 py-2 font-semibold text-white transition hover:bg-indigo-700">
+                    Verify
+                </button>
+            </form>
+        </div>
+    </div>
+@endsection

--- a/resources/views/auth/two-factor.blade.php
+++ b/resources/views/auth/two-factor.blade.php
@@ -1,0 +1,78 @@
+@extends('layouts.app')
+
+@section('content')
+    <div class="min-h-screen bg-gray-100 px-4 py-12">
+        <div class="mx-auto w-full max-w-xl rounded-lg bg-white p-8 shadow">
+            <div class="mb-6 flex items-center justify-between">
+                <h1 class="text-2xl font-semibold text-gray-800">Two-factor authentication</h1>
+                <a href="{{ url('/') }}" class="text-sm text-indigo-600 hover:underline">&larr; Dashboard</a>
+            </div>
+
+            @if (session('success'))
+                <div class="mb-4 rounded-md bg-green-100 px-4 py-3 text-sm text-green-800">{{ session('success') }}</div>
+            @endif
+            @if ($errors->any())
+                <div class="mb-4 rounded-md bg-red-100 px-4 py-3 text-sm text-red-700">{{ $errors->first() }}</div>
+            @endif
+
+            @if ($recoveryCodes)
+                <div class="mb-6 rounded-md border border-yellow-300 bg-yellow-50 p-4">
+                    <p class="mb-2 text-sm font-medium text-yellow-800">Recovery codes — store these somewhere safe. Each can be used once.</p>
+                    <div class="grid grid-cols-2 gap-1 font-mono text-sm text-gray-800">
+                        @foreach ($recoveryCodes as $code)
+                            <span>{{ $code }}</span>
+                        @endforeach
+                    </div>
+                </div>
+            @endif
+
+            @if ($user->hasTwoFactorEnabled())
+                <p class="mb-4 rounded-md bg-green-50 px-4 py-3 text-sm text-green-800">
+                    Two-factor authentication is <strong>enabled</strong> for your account.
+                </p>
+                <form method="POST" action="{{ route('two-factor.disable') }}"
+                    onsubmit="return confirm('Disable two-factor authentication?');">
+                    @csrf
+                    <button type="submit" class="rounded-md bg-red-600 px-4 py-2 font-semibold text-white hover:bg-red-700">
+                        Disable two-factor
+                    </button>
+                </form>
+            @elseif ($provisioningUri)
+                <p class="mb-4 text-sm text-gray-600">Scan this QR code with your authenticator app, then enter a code to confirm.</p>
+
+                <div id="qr" class="mb-4 flex justify-center"></div>
+                <p class="mb-4 break-all text-center text-xs text-gray-500">
+                    Or enter this secret manually: <span class="font-mono">{{ $user->two_factor_secret }}</span>
+                </p>
+
+                <form method="POST" action="{{ route('two-factor.confirm') }}" class="flex items-center gap-2">
+                    @csrf
+                    <input name="code" type="text" inputmode="numeric" placeholder="123456" required
+                        class="flex-1 rounded-md border border-gray-300 px-3 py-2 tracking-widest focus:border-indigo-500 focus:outline-none focus:ring-1 focus:ring-indigo-500">
+                    <button type="submit" class="rounded-md bg-indigo-600 px-4 py-2 font-semibold text-white hover:bg-indigo-700">
+                        Confirm
+                    </button>
+                </form>
+
+                <script src="https://cdn.jsdelivr.net/npm/qrcodejs@1.0.0/qrcode.min.js"></script>
+                <script>
+                    new QRCode(document.getElementById('qr'), {
+                        text: @json($provisioningUri),
+                        width: 180,
+                        height: 180,
+                    });
+                </script>
+            @else
+                <p class="mb-4 text-sm text-gray-600">
+                    Add a second step to logins using an authenticator app (e.g. Google Authenticator, 1Password, Authy).
+                </p>
+                <form method="POST" action="{{ route('two-factor.enable') }}">
+                    @csrf
+                    <button type="submit" class="rounded-md bg-indigo-600 px-4 py-2 font-semibold text-white hover:bg-indigo-700">
+                        Enable two-factor
+                    </button>
+                </form>
+            @endif
+        </div>
+    </div>
+@endsection

--- a/resources/views/home.blade.php
+++ b/resources/views/home.blade.php
@@ -4,12 +4,18 @@
     <div class="min-h-screen">
         <div class="flex items-center justify-between px-12 pt-8">
             <h1 class="text-2xl font-semibold text-gray-800">Laravel Deployer</h1>
-            <form method="POST" action="{{ route('logout') }}">
-                @csrf
-                <button type="submit" class="rounded-md bg-gray-700 px-4 py-2 text-sm text-white hover:bg-gray-800">
-                    Log out
-                </button>
-            </form>
+            <div class="flex items-center gap-3">
+                <a href="{{ route('two-factor.index') }}"
+                    class="rounded-md bg-gray-200 px-4 py-2 text-sm text-gray-800 hover:bg-gray-300">
+                    Two-factor
+                </a>
+                <form method="POST" action="{{ route('logout') }}">
+                    @csrf
+                    <button type="submit" class="rounded-md bg-gray-700 px-4 py-2 text-sm text-white hover:bg-gray-800">
+                        Log out
+                    </button>
+                </form>
+            </div>
         </div>
 
         @if (session('success'))

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Auth\AuthController;
+use App\Http\Controllers\Auth\TwoFactorController;
 use App\Http\Controllers\DeploymentController;
 use Illuminate\Support\Facades\Route;
 
@@ -19,6 +20,10 @@ use Illuminate\Support\Facades\Route;
 Route::middleware('guest')->group(function () {
     Route::get('login', [AuthController::class, 'showLogin'])->name('login');
     Route::post('login', [AuthController::class, 'login'])->name('login.attempt');
+
+    // Two-factor challenge (after a correct password, before full login).
+    Route::get('two-factor-challenge', [AuthController::class, 'showChallenge'])->name('two-factor.challenge');
+    Route::post('two-factor-challenge', [AuthController::class, 'challenge'])->name('two-factor.verify');
 });
 
 Route::post('logout', [AuthController::class, 'logout'])->name('logout')->middleware('auth');
@@ -30,6 +35,12 @@ Route::middleware('auth')->group(function () {
     // Read-only downloads
     Route::get('download/{folder}', [DeploymentController::class, 'download'])->name('download');
     Route::get('download-db/{db_file}', [DeploymentController::class, 'downloadDb'])->name('downloadDb');
+
+    // Two-factor settings
+    Route::get('two-factor', [TwoFactorController::class, 'index'])->name('two-factor.index');
+    Route::post('two-factor/enable', [TwoFactorController::class, 'enable'])->name('two-factor.enable');
+    Route::post('two-factor/confirm', [TwoFactorController::class, 'confirm'])->name('two-factor.confirm');
+    Route::post('two-factor/disable', [TwoFactorController::class, 'disable'])->name('two-factor.disable');
 
     // Live deploy status (polled by the dashboard)
     Route::get('deploy-status', [DeploymentController::class, 'deployStatus'])->name('deploy.status');

--- a/tests/Feature/TwoFactorTest.php
+++ b/tests/Feature/TwoFactorTest.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Support\Totp;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class TwoFactorTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_user_can_enable_and_confirm_two_factor(): void
+    {
+        $user = User::factory()->create();
+
+        $this->actingAs($user)->post(route('two-factor.enable'))->assertRedirect();
+        $user->refresh();
+        $this->assertNotNull($user->two_factor_secret);
+        $this->assertFalse($user->hasTwoFactorEnabled());
+
+        $this->actingAs($user)
+            ->post(route('two-factor.confirm'), ['code' => Totp::now($user->two_factor_secret)])
+            ->assertSessionHas('recovery_codes');
+
+        $this->assertTrue($user->fresh()->hasTwoFactorEnabled());
+    }
+
+    public function test_confirm_rejects_an_invalid_code(): void
+    {
+        $user = User::factory()->create(['two_factor_secret' => Totp::generateSecret()]);
+
+        $this->actingAs($user)
+            ->post(route('two-factor.confirm'), ['code' => '000000'])
+            ->assertSessionHasErrors('code');
+
+        $this->assertFalse($user->fresh()->hasTwoFactorEnabled());
+    }
+
+    public function test_login_with_two_factor_redirects_to_challenge(): void
+    {
+        $user = $this->userWithTwoFactor();
+
+        $this->post(route('login.attempt'), ['email' => $user->email, 'password' => 'secret-password'])
+            ->assertRedirect(route('two-factor.challenge'));
+
+        $this->assertGuest();
+    }
+
+    public function test_challenge_completes_login_with_a_valid_code(): void
+    {
+        $user = $this->userWithTwoFactor();
+
+        $this->post(route('login.attempt'), ['email' => $user->email, 'password' => 'secret-password']);
+
+        $this->post(route('two-factor.verify'), ['code' => Totp::now($user->two_factor_secret)])
+            ->assertRedirect('/');
+
+        $this->assertAuthenticatedAs($user->fresh());
+    }
+
+    public function test_challenge_accepts_a_recovery_code_once(): void
+    {
+        $user = $this->userWithTwoFactor(['recovery-code-1', 'recovery-code-2']);
+
+        $this->post(route('login.attempt'), ['email' => $user->email, 'password' => 'secret-password']);
+        $this->post(route('two-factor.verify'), ['recovery_code' => 'recovery-code-1'])->assertRedirect('/');
+
+        $this->assertAuthenticated();
+        $this->assertNotContains('recovery-code-1', $user->fresh()->two_factor_recovery_codes);
+    }
+
+    public function test_challenge_rejects_an_invalid_code(): void
+    {
+        $user = $this->userWithTwoFactor();
+
+        $this->post(route('login.attempt'), ['email' => $user->email, 'password' => 'secret-password']);
+        $this->post(route('two-factor.verify'), ['code' => '000000'])->assertSessionHasErrors('code');
+
+        $this->assertGuest();
+    }
+
+    public function test_user_can_disable_two_factor(): void
+    {
+        $user = $this->userWithTwoFactor();
+
+        $this->actingAs($user)->post(route('two-factor.disable'))->assertRedirect();
+
+        $this->assertFalse($user->fresh()->hasTwoFactorEnabled());
+    }
+
+    protected function userWithTwoFactor(array $recoveryCodes = ['code-a', 'code-b']): User
+    {
+        return User::factory()->create([
+            'password' => Hash::make('secret-password'),
+            'two_factor_secret' => Totp::generateSecret(),
+            'two_factor_recovery_codes' => $recoveryCodes,
+            'two_factor_confirmed_at' => now(),
+        ]);
+    }
+}

--- a/tests/Unit/TotpTest.php
+++ b/tests/Unit/TotpTest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Support\Totp;
+use PHPUnit\Framework\TestCase;
+
+class TotpTest extends TestCase
+{
+    public function test_a_freshly_generated_code_verifies(): void
+    {
+        $secret = Totp::generateSecret();
+
+        $this->assertTrue(Totp::verify($secret, Totp::now($secret)));
+    }
+
+    public function test_a_wrong_code_is_rejected(): void
+    {
+        $secret = Totp::generateSecret();
+
+        $this->assertFalse(Totp::verify($secret, '000000'));
+        $this->assertFalse(Totp::verify($secret, 'not-a-code'));
+    }
+
+    public function test_secret_is_base32_and_uri_is_well_formed(): void
+    {
+        $secret = Totp::generateSecret();
+
+        $this->assertMatchesRegularExpression('/^[A-Z2-7]{32}$/', $secret);
+        $this->assertStringContainsString('otpauth://totp/', Totp::uri($secret, 'admin@example.com', 'Deployer'));
+    }
+}


### PR DESCRIPTION
## Summary
Adds optional authenticator-app 2FA for the admin account — this dashboard can deploy code, so a second factor matters.

- **Enroll** from the dashboard (*Two-factor*): scan the QR (or enter the secret), confirm a code, save the eight one-time **recovery codes**.
- **Login** becomes a password step that, when 2FA is enabled, defers to a TOTP challenge before completing. Recovery codes work as a fallback and are consumed on use.
- The existing login rate limiter also guards the challenge.

## Implementation
- Dependency-free RFC 6238 TOTP (`App\Support\Totp`) — SHA-1, 6 digits, 30s, ±1 step drift.
- Encrypted `two_factor_secret` / `two_factor_recovery_codes` / `two_factor_confirmed_at` columns; `User::hasTwoFactorEnabled()` / `useRecoveryCode()`.
- `TwoFactorController` (enable/confirm/disable) + challenge in `AuthController`.

## Verification
- Unit tests for the TOTP primitive (verify/reject/secret format).
- Feature tests: enable+confirm, invalid confirm, login→challenge redirect, challenge with code, recovery-code single use, invalid challenge, disable.
- 67 tests pass; `pint --test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)