### PR TITLE
Notify on deploy success and failure

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -80,6 +80,11 @@ DEPLOYER_HEALTH_DELAY=3
 # production). Ignored on the local environment.
 DEPLOYER_FORCE_HTTPS=false
 
+# Deploy notifications (optional). Notify on success/failure via a Slack
+# incoming webhook and/or email. Leave blank to disable.
+DEPLOYER_SLACK_WEBHOOK=
+DEPLOYER_NOTIFY_EMAIL=
+
 # ---------------------------------------------------------------------------
 # Database that the DEPLOYED application uses (dumped before each release,
 # and restorable from the dashboard). Leave blank to skip DB backups.

--- a/README.md
+++ b/README.md
@@ -159,6 +159,8 @@ All deployment settings live in `config/deployer.php` and are driven by `.env`.
 | `DEPLOYER_DEPLOY_TIMEOUT` | Seconds before a stuck "running" deploy is stale | `1800` |
 | `DEPLOYER_HEALTH_URL` | Probe after switch; auto-rollback on failure (unset = off) | `https://app.example.com/up` |
 | `DEPLOYER_HEALTH_RETRIES` / `DEPLOYER_HEALTH_DELAY` | Probe attempts and seconds between them | `5` / `3` |
+| `DEPLOYER_FORCE_HTTPS` | Redirect to HTTPS + send HSTS (off on local) | `false` |
+| `DEPLOYER_SLACK_WEBHOOK` / `DEPLOYER_NOTIFY_EMAIL` | Notify on deploy success/failure (blank = off) | |
 | `DEPLOYER_DB_NAME` | Database of the **deployed app** to dump/restore | `myapp` |
 | `DEPLOYER_DB_USER` / `DEPLOYER_DB_PASSWORD` | Credentials for that database | |
 | `DEPLOYER_DB_HOST` / `DEPLOYER_DB_PORT` | Host/port for that database | `127.0.0.1` / `3306` |

--- a/app/Console/Commands/Deploy.php
+++ b/app/Console/Commands/Deploy.php
@@ -3,6 +3,7 @@
 namespace App\Console\Commands;
 
 use App\Support\Database;
+use App\Support\DeployNotifier;
 use App\Support\DeployState;
 use App\Support\HealthCheck;
 use App\Support\Releases;
@@ -51,9 +52,8 @@ class Deploy extends Command
 
             if (empty($git_remote_url)) {
                 $this->error('GIT_REMOTE_URL is not configured.');
-                DeployState::markFinished($id, false, 'GIT_REMOTE_URL is not configured.');
 
-                return self::FAILURE;
+                return $this->finish($id, false, 'GIT_REMOTE_URL is not configured.');
             }
 
             // Note: $serve_dir is intentionally not pre-created — it is managed
@@ -66,9 +66,8 @@ class Deploy extends Command
             $ref = trim((string) $this->option('ref'));
             if ($ref !== '' && ! self::isValidRef($ref)) {
                 $this->error("Invalid git ref: {$ref}");
-                DeployState::markFinished($id, false, "Invalid git ref: {$ref}");
 
-                return self::FAILURE;
+                return $this->finish($id, false, "Invalid git ref: {$ref}");
             }
 
             // Clone the repository into the new release directory.
@@ -154,9 +153,8 @@ class Deploy extends Command
                         ? "Health check failed; rolled back to {$previousLive}."
                         : 'Health check failed; no previous release to roll back to.';
                     $this->error($message);
-                    DeployState::markFinished($id, false, $message);
 
-                    return self::FAILURE;
+                    return $this->finish($id, false, $message);
                 }
 
                 $this->info('Health check passed.');
@@ -170,16 +168,25 @@ class Deploy extends Command
             }
 
             $this->info("Deployed release {$tag}.");
-            DeployState::markFinished($id, true, "Deployed release {$tag}.");
 
-            return self::SUCCESS;
+            return $this->finish($id, true, "Deployed release {$tag}.");
         } catch (Throwable $th) {
             Log::error('Deployment failed', ['exception' => $th]);
             $this->error($th->getMessage());
-            DeployState::markFinished($id, false, $th->getMessage());
 
-            return self::FAILURE;
+            return $this->finish($id, false, $th->getMessage());
         }
+    }
+
+    /**
+     * Record the final deploy state, send notifications and map to an exit code.
+     */
+    protected function finish(string $id, bool $ok, string $message): int
+    {
+        DeployState::markFinished($id, $ok, $message);
+        DeployNotifier::send($ok, $message);
+
+        return $ok ? self::SUCCESS : self::FAILURE;
     }
 
     protected function ensureDirectory(string $path): void

--- a/app/Support/DeployNotifier.php
+++ b/app/Support/DeployNotifier.php
@@ -1,0 +1,56 @@
+<?php
+
+namespace App\Support;
+
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Log;
+use Illuminate\Support\Facades\Mail;
+use Throwable;
+
+/**
+ * Sends deploy success/failure notifications to a Slack webhook and/or an
+ * email address. Both are optional; a missing channel is silently skipped,
+ * and a delivery failure is logged but never fails the deploy.
+ */
+class DeployNotifier
+{
+    public static function send(bool $ok, string $message): void
+    {
+        $status = $ok ? 'succeeded' : 'failed';
+        $appName = (string) config('app.name', 'Laravel Deployer');
+        $text = "[{$appName}] Deploy {$status}: {$message}";
+
+        self::slack($text);
+        self::email("Deploy {$status}", $text);
+    }
+
+    protected static function slack(string $text): void
+    {
+        $webhook = (string) config('deployer.notify_slack_webhook');
+        if ($webhook === '') {
+            return;
+        }
+
+        try {
+            Http::timeout(10)->post($webhook, ['text' => $text]);
+        } catch (Throwable $e) {
+            Log::warning('Deploy Slack notification failed', ['exception' => $e]);
+        }
+    }
+
+    protected static function email(string $subject, string $body): void
+    {
+        $to = (string) config('deployer.notify_email');
+        if ($to === '') {
+            return;
+        }
+
+        try {
+            Mail::raw($body, function ($mail) use ($to, $subject) {
+                $mail->to($to)->subject($subject);
+            });
+        } catch (Throwable $e) {
+            Log::warning('Deploy email notification failed', ['exception' => $e]);
+        }
+    }
+}

--- a/config/deployer.php
+++ b/config/deployer.php
@@ -41,4 +41,8 @@ return [
     // Redirect insecure requests to HTTPS and emit HSTS. Strongly recommended
     // in production; ignored on the local environment.
     'force_https' => (bool) env('DEPLOYER_FORCE_HTTPS', false),
+
+    // Deploy notifications. Both are optional; leave blank to disable.
+    'notify_slack_webhook' => env('DEPLOYER_SLACK_WEBHOOK'),
+    'notify_email' => env('DEPLOYER_NOTIFY_EMAIL'),
 ];

--- a/tests/Feature/DeployNotifierTest.php
+++ b/tests/Feature/DeployNotifierTest.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Support\DeployNotifier;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Mail;
+use Tests\TestCase;
+
+class DeployNotifierTest extends TestCase
+{
+    public function test_it_posts_to_slack_when_a_webhook_is_configured(): void
+    {
+        config(['deployer.notify_slack_webhook' => 'https://hooks.slack.test/abc', 'deployer.notify_email' => null]);
+        Http::fake();
+
+        DeployNotifier::send(true, 'release 2024 live');
+
+        Http::assertSent(function ($request) {
+            return $request->url() === 'https://hooks.slack.test/abc'
+                && str_contains($request['text'], 'succeeded')
+                && str_contains($request['text'], 'release 2024 live');
+        });
+    }
+
+    public function test_it_does_not_call_slack_when_unset(): void
+    {
+        config(['deployer.notify_slack_webhook' => null, 'deployer.notify_email' => null]);
+        Http::fake();
+
+        DeployNotifier::send(false, 'boom');
+
+        Http::assertNothingSent();
+    }
+
+    public function test_it_emails_when_an_address_is_configured(): void
+    {
+        config(['deployer.notify_slack_webhook' => null, 'deployer.notify_email' => 'ops@example.com']);
+
+        DeployNotifier::send(false, 'boom');
+
+        $messages = Mail::getSymfonyTransport()->messages();
+        $this->assertCount(1, $messages);
+        $this->assertStringContainsString('failed', $messages[0]->getOriginalMessage()->getSubject());
+    }
+
+    public function test_it_is_a_noop_when_no_channel_is_configured(): void
+    {
+        config(['deployer.notify_slack_webhook' => null, 'deployer.notify_email' => null]);
+
+        DeployNotifier::send(true, 'ok');
+
+        $this->assertCount(0, Mail::getSymfonyTransport()->messages());
+    }
+}


### PR DESCRIPTION
## Summary
Optional deploy notifications via **Slack webhook** and/or **email**.

- `App\Support\DeployNotifier` posts to a Slack incoming webhook and/or sends an email on every deploy outcome (success, failure, health-rollback, invalid input).
- Both channels are optional and skipped when unset; a delivery failure is logged and never breaks the deploy.
- All deploy exits now route through one `finish()` helper that records state and notifies.

## Verification
- Feature tests: Slack posts when configured, no call when unset, email sent via the array transport, full no-op when nothing is configured.
- 71 tests pass; `pint --test` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)