### PR TITLE
Remote deploy API (closes #3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,28 @@ All actions require confirmation and are protected by authentication and CSRF.
 
 ---
 
+## Remote API
+
+Trigger and monitor deploys from CI or scripts using a [Sanctum](https://laravel.com/docs/sanctum) token. Mint one with:
+
+```bash
+php artisan deployer:token "ci"        # uses the first admin; or --email=you@example.com
+```
+
+| Method & path | Purpose |
+| --- | --- |
+| `POST /api/deploy` | Start a deploy. Optional `ref` (branch/tag/commit). `202` on launch, `409` if one is already running, `422` for an invalid ref. |
+| `GET /api/deploy/status` | Current deploy status (`idle`/`running`/`success`/`failed`). |
+
+```bash
+curl -X POST https://deployer.example.com/api/deploy \
+  -H "Authorization: Bearer <token>" \
+  -H "Accept: application/json" \
+  -d ref=main
+```
+
+---
+
 ## Configuration
 
 All deployment settings live in `config/deployer.php` and are driven by `.env`.

--- a/app/Console/Commands/CreateApiToken.php
+++ b/app/Console/Commands/CreateApiToken.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Models\User;
+use Illuminate\Console\Command;
+
+class CreateApiToken extends Command
+{
+    protected $signature = 'deployer:token {name : A label for the token} {--email= : Admin email (defaults to the first user)}';
+
+    protected $description = 'Create a Sanctum API token for controlling deploys remotely';
+
+    public function handle(): int
+    {
+        $email = $this->option('email');
+
+        $user = $email
+            ? User::where('email', $email)->first()
+            : User::query()->orderBy('id')->first();
+
+        if (! $user) {
+            $this->error($email ? "No user found for {$email}." : 'No users exist. Seed an admin first.');
+
+            return self::FAILURE;
+        }
+
+        $token = $user->createToken($this->argument('name'));
+
+        $this->info("Token created for {$user->email}:");
+        $this->line($token->plainTextToken);
+        $this->newLine();
+        $this->comment('Store it now — it will not be shown again. Use it as: Authorization: Bearer <token>');
+
+        return self::SUCCESS;
+    }
+}

--- a/app/Http/Controllers/Api/DeployApiController.php
+++ b/app/Http/Controllers/Api/DeployApiController.php
@@ -1,0 +1,51 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Console\Commands\Deploy as DeployCommand;
+use App\Http\Controllers\Controller;
+use App\Support\DeployLauncher;
+use App\Support\DeployState;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+class DeployApiController extends Controller
+{
+    /**
+     * Trigger a deploy. Optional `ref` (branch/tag/commit). Returns 202 on
+     * launch, 409 if one is already running, 422 for an invalid ref.
+     */
+    public function deploy(Request $request, DeployLauncher $launcher): JsonResponse
+    {
+        $ref = trim((string) $request->input('ref', ''));
+
+        if ($ref !== '' && ! DeployCommand::isValidRef($ref)) {
+            return response()->json(['message' => 'Invalid branch, tag or commit reference.'], 422);
+        }
+
+        if (! $launcher->trigger($ref)) {
+            return response()->json(['message' => 'A deploy is already in progress.'], 409);
+        }
+
+        return response()->json([
+            'message' => 'Deploy started.',
+            'status' => DeployState::status(),
+        ], 202);
+    }
+
+    /**
+     * Current deploy status and whether one is running.
+     */
+    public function status(): JsonResponse
+    {
+        $status = DeployState::status();
+
+        return response()->json([
+            'status' => $status['status'],
+            'message' => $status['message'],
+            'running' => DeployState::running(),
+            'started_at' => $status['started_at'],
+            'finished_at' => $status['finished_at'],
+        ]);
+    }
+}

--- a/app/Http/Controllers/DeploymentController.php
+++ b/app/Http/Controllers/DeploymentController.php
@@ -117,19 +117,14 @@ class DeploymentController extends Controller
 
     public function deploy(Request $request, DeployLauncher $launcher): RedirectResponse
     {
-        if (DeployState::running()) {
-            return back()->with('error', 'A deploy is already in progress.');
-        }
-
         $ref = trim((string) $request->input('ref', ''));
         if ($ref !== '' && ! DeployCommand::isValidRef($ref)) {
             return back()->with('error', 'Invalid branch, tag or commit reference.');
         }
 
-        // Mark running synchronously so the dashboard reflects it immediately,
-        // then launch the deploy in a detached background process.
-        DeployState::markStarted();
-        $launcher->launch($ref);
+        if (! $launcher->trigger($ref)) {
+            return back()->with('error', 'A deploy is already in progress.');
+        }
 
         return back()->with('success', 'Deploy started. Watch the log for progress.');
     }

--- a/app/Support/DeployLauncher.php
+++ b/app/Support/DeployLauncher.php
@@ -13,6 +13,23 @@ use Symfony\Component\Process\Process;
  */
 class DeployLauncher
 {
+    /**
+     * Start a deploy unless one is already running. Marks the run started
+     * synchronously and launches it in the background. Returns false when a
+     * deploy is already in progress.
+     */
+    public function trigger(?string $ref = null): bool
+    {
+        if (DeployState::running()) {
+            return false;
+        }
+
+        DeployState::markStarted();
+        $this->launch($ref);
+
+        return true;
+    }
+
     public function launch(?string $ref = null): void
     {
         $php = (string) config('deployer.php_binary', 'php');

--- a/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
+++ b/database/migrations/2019_12_14_000001_create_personal_access_tokens_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('personal_access_tokens', function (Blueprint $table) {
+            $table->id();
+            $table->morphs('tokenable');
+            $table->text('name');
+            $table->string('token', 64)->unique();
+            $table->text('abilities')->nullable();
+            $table->timestamp('last_used_at')->nullable();
+            $table->timestamp('expires_at')->nullable()->index();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('personal_access_tokens');
+    }
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,5 +1,6 @@
 <?php
 
+use App\Http\Controllers\Api\DeployApiController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -8,12 +9,14 @@ use Illuminate\Support\Facades\Route;
 | API Routes
 |--------------------------------------------------------------------------
 |
-| Here is where you can register API routes for your application. These
-| routes are loaded by the RouteServiceProvider within a group which
-| is assigned the "api" middleware group. Enjoy building your API!
+| Token-authenticated endpoints (Laravel Sanctum) for controlling deploys
+| remotely. Mint a token with: php artisan deployer:token "ci"
 |
 */
 
-Route::middleware('auth:sanctum')->get('/user', function (Request $request) {
-    return $request->user();
+Route::middleware('auth:sanctum')->group(function () {
+    Route::get('/user', fn (Request $request) => $request->user());
+
+    Route::post('/deploy', [DeployApiController::class, 'deploy'])->name('api.deploy');
+    Route::get('/deploy/status', [DeployApiController::class, 'status'])->name('api.deploy.status');
 });

--- a/tests/Feature/DeployApiTest.php
+++ b/tests/Feature/DeployApiTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Support\DeployLauncher;
+use App\Support\DeployState;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class DeployApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected string $base;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->base = sys_get_temp_dir().'/deployer_api_'.uniqid();
+        mkdir($this->base, 0755, true);
+        config(['deployer.base_dir' => $this->base, 'deployer.deploy_timeout' => 1800]);
+    }
+
+    protected function tearDown(): void
+    {
+        @exec('rm -rf '.escapeshellarg($this->base));
+        parent::tearDown();
+    }
+
+    protected function fakeLauncher(): object
+    {
+        $launcher = new class extends DeployLauncher
+        {
+            public bool $launched = false;
+
+            public ?string $ref = null;
+
+            public function launch(?string $ref = null): void
+            {
+                $this->launched = true;
+                $this->ref = $ref;
+            }
+        };
+
+        $this->app->instance(DeployLauncher::class, $launcher);
+
+        return $launcher;
+    }
+
+    public function test_unauthenticated_requests_are_rejected(): void
+    {
+        $this->postJson('/api/deploy')->assertUnauthorized();
+        $this->getJson('/api/deploy/status')->assertUnauthorized();
+    }
+
+    public function test_token_user_can_trigger_a_deploy(): void
+    {
+        Sanctum::actingAs(User::factory()->create());
+        $launcher = $this->fakeLauncher();
+
+        $this->postJson('/api/deploy', ['ref' => 'main'])
+            ->assertStatus(202)
+            ->assertJsonPath('message', 'Deploy started.');
+
+        $this->assertTrue($launcher->launched);
+        $this->assertSame('main', $launcher->ref);
+        $this->assertSame(DeployState::RUNNING, DeployState::status()['status']);
+    }
+
+    public function test_trigger_is_conflicted_while_running(): void
+    {
+        DeployState::markStarted('busy');
+        Sanctum::actingAs(User::factory()->create());
+        $launcher = $this->fakeLauncher();
+
+        $this->postJson('/api/deploy')->assertStatus(409);
+        $this->assertFalse($launcher->launched);
+    }
+
+    public function test_invalid_ref_is_rejected(): void
+    {
+        Sanctum::actingAs(User::factory()->create());
+        $launcher = $this->fakeLauncher();
+
+        $this->postJson('/api/deploy', ['ref' => 'bad;rm'])->assertStatus(422);
+        $this->assertFalse($launcher->launched);
+    }
+
+    public function test_status_endpoint_returns_state(): void
+    {
+        DeployState::markStarted('run-1');
+        Sanctum::actingAs(User::factory()->create());
+
+        $this->getJson('/api/deploy/status')
+            ->assertOk()
+            ->assertJson(['status' => DeployState::RUNNING, 'running' => true]);
+    }
+
+    public function test_token_command_creates_a_token(): void
+    {
+        $user = User::factory()->create();
+
+        $this->artisan('deployer:token', ['name' => 'ci', '--email' => $user->email])
+            ->assertExitCode(0);
+
+        $this->assertDatabaseHas('personal_access_tokens', [
+            'tokenable_id' => $user->id,
+            'name' => 'ci',
+        ]);
+    }
+}


### PR DESCRIPTION
## Summary
Adds a token-authenticated API to control deploys remotely (issue #3).

- `POST /api/deploy` — start a deploy, optional `ref`; `202` launched / `409` already running / `422` invalid ref.
- `GET /api/deploy/status` — current status.
- `php artisan deployer:token "ci"` mints a Sanctum token; the personal-access-tokens migration is now published.
- Shared `DeployLauncher::trigger()` powers both the dashboard and the API (no duplication).

## Verification
- Feature tests: unauthenticated 401, trigger 202 + launched, 409 conflict, 422 invalid ref, status JSON, token command creates a row.
- 81 tests pass; `pint --test` clean.

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)