### PR TITLE
GitHub push webhook (closes #1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,6 +85,12 @@ DEPLOYER_FORCE_HTTPS=false
 DEPLOYER_SLACK_WEBHOOK=
 DEPLOYER_NOTIFY_EMAIL=
 
+# GitHub push webhook. Set the secret (same value in the GitHub webhook
+# settings) to enable POST /api/webhooks/github. Optionally restrict to a
+# single branch; blank deploys whichever branch was pushed.
+DEPLOYER_GITHUB_WEBHOOK_SECRET=
+DEPLOYER_WEBHOOK_BRANCH=
+
 # ---------------------------------------------------------------------------
 # Database that the DEPLOYED application uses (dumped before each release,
 # and restorable from the dashboard). Leave blank to skip DB backups.

--- a/README.md
+++ b/README.md
@@ -161,6 +161,10 @@ curl -X POST https://deployer.example.com/api/deploy \
   -d ref=main
 ```
 
+### GitHub webhook
+
+Set `DEPLOYER_GITHUB_WEBHOOK_SECRET` to enable `POST /api/webhooks/github`, then add a GitHub webhook (content type `application/json`, the same secret, the *push* event). Each push triggers a deploy of the pushed branch; the signature is verified via `X-Hub-Signature-256`. Restrict to one branch with `DEPLOYER_WEBHOOK_BRANCH` (blank = deploy whichever branch was pushed).
+
 ---
 
 ## Configuration

--- a/app/Http/Controllers/Api/GitHubWebhookController.php
+++ b/app/Http/Controllers/Api/GitHubWebhookController.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace App\Http\Controllers\Api;
+
+use App\Console\Commands\Deploy as DeployCommand;
+use App\Http\Controllers\Controller;
+use App\Support\DeployLauncher;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Receives GitHub push webhooks and triggers a deploy. The request is
+ * authenticated by verifying the HMAC signature against a shared secret, so
+ * no Sanctum token is needed (and must not be required) for this endpoint.
+ */
+class GitHubWebhookController extends Controller
+{
+    public function handle(Request $request, DeployLauncher $launcher): JsonResponse
+    {
+        $secret = (string) config('deployer.github_webhook_secret');
+
+        if ($secret === '') {
+            return response()->json(['message' => 'Webhook is not configured.'], 404);
+        }
+
+        if (! $this->signatureIsValid($request, $secret)) {
+            return response()->json(['message' => 'Invalid signature.'], 401);
+        }
+
+        $event = $request->header('X-GitHub-Event');
+
+        if ($event === 'ping') {
+            return response()->json(['message' => 'pong']);
+        }
+
+        if ($event !== 'push') {
+            return response()->json(['message' => 'Ignored event.'], 200);
+        }
+
+        // Extract the pushed branch from refs/heads/<branch>.
+        $ref = (string) $request->input('ref');
+        $branch = str_starts_with($ref, 'refs/heads/') ? substr($ref, strlen('refs/heads/')) : null;
+
+        $only = (string) config('deployer.webhook_branch');
+        if ($only !== '' && $branch !== $only) {
+            return response()->json(['message' => "Ignored branch: {$branch}."], 200);
+        }
+
+        if ($branch !== null && ! DeployCommand::isValidRef($branch)) {
+            return response()->json(['message' => 'Invalid branch reference.'], 422);
+        }
+
+        if (! $launcher->trigger($branch ?: null)) {
+            return response()->json(['message' => 'A deploy is already in progress.'], 409);
+        }
+
+        return response()->json(['message' => 'Deploy started.', 'branch' => $branch], 202);
+    }
+
+    protected function signatureIsValid(Request $request, string $secret): bool
+    {
+        $signature = (string) $request->header('X-Hub-Signature-256');
+        if ($signature === '') {
+            return false;
+        }
+
+        $expected = 'sha256='.hash_hmac('sha256', $request->getContent(), $secret);
+
+        return hash_equals($expected, $signature);
+    }
+}

--- a/config/deployer.php
+++ b/config/deployer.php
@@ -45,4 +45,9 @@ return [
     // Deploy notifications. Both are optional; leave blank to disable.
     'notify_slack_webhook' => env('DEPLOYER_SLACK_WEBHOOK'),
     'notify_email' => env('DEPLOYER_NOTIFY_EMAIL'),
+
+    // GitHub push webhook. Set the secret to enable POST /api/webhooks/github;
+    // restrict to a single branch with DEPLOYER_WEBHOOK_BRANCH (blank = any).
+    'github_webhook_secret' => env('DEPLOYER_GITHUB_WEBHOOK_SECRET'),
+    'webhook_branch' => env('DEPLOYER_WEBHOOK_BRANCH'),
 ];

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,7 @@
 <?php
 
 use App\Http\Controllers\Api\DeployApiController;
+use App\Http\Controllers\Api\GitHubWebhookController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
 
@@ -20,3 +21,6 @@ Route::middleware('auth:sanctum')->group(function () {
     Route::post('/deploy', [DeployApiController::class, 'deploy'])->name('api.deploy');
     Route::get('/deploy/status', [DeployApiController::class, 'status'])->name('api.deploy.status');
 });
+
+// GitHub push webhook — authenticated by HMAC signature, not a token.
+Route::post('/webhooks/github', [GitHubWebhookController::class, 'handle'])->name('api.webhooks.github');

--- a/tests/Feature/GitHubWebhookTest.php
+++ b/tests/Feature/GitHubWebhookTest.php
@@ -1,0 +1,119 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Support\DeployLauncher;
+use App\Support\DeployState;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Testing\TestResponse;
+use Tests\TestCase;
+
+class GitHubWebhookTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected string $base;
+
+    protected string $secret = 'shhh-secret';
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->base = sys_get_temp_dir().'/deployer_hook_'.uniqid();
+        mkdir($this->base, 0755, true);
+        config([
+            'deployer.base_dir' => $this->base,
+            'deployer.github_webhook_secret' => $this->secret,
+            'deployer.webhook_branch' => null,
+        ]);
+    }
+
+    protected function tearDown(): void
+    {
+        @exec('rm -rf '.escapeshellarg($this->base));
+        parent::tearDown();
+    }
+
+    protected function fakeLauncher(): object
+    {
+        $launcher = new class extends DeployLauncher
+        {
+            public bool $launched = false;
+
+            public ?string $ref = null;
+
+            public function launch(?string $ref = null): void
+            {
+                $this->launched = true;
+                $this->ref = $ref;
+            }
+        };
+
+        $this->app->instance(DeployLauncher::class, $launcher);
+
+        return $launcher;
+    }
+
+    protected function send(array $payload, string $event = 'push', ?string $secret = null): TestResponse
+    {
+        $body = json_encode($payload);
+        $signature = 'sha256='.hash_hmac('sha256', $body, $secret ?? $this->secret);
+
+        return $this->call('POST', '/api/webhooks/github', [], [], [], [
+            'HTTP_X_GITHUB_EVENT' => $event,
+            'HTTP_X_HUB_SIGNATURE_256' => $signature,
+            'CONTENT_TYPE' => 'application/json',
+        ], $body);
+    }
+
+    public function test_valid_push_triggers_a_deploy_of_the_pushed_branch(): void
+    {
+        $launcher = $this->fakeLauncher();
+
+        $this->send(['ref' => 'refs/heads/main'])->assertStatus(202);
+
+        $this->assertTrue($launcher->launched);
+        $this->assertSame('main', $launcher->ref);
+        $this->assertSame(DeployState::RUNNING, DeployState::status()['status']);
+    }
+
+    public function test_invalid_signature_is_rejected(): void
+    {
+        $launcher = $this->fakeLauncher();
+
+        $this->send(['ref' => 'refs/heads/main'], secret: 'wrong-secret')->assertStatus(401);
+
+        $this->assertFalse($launcher->launched);
+    }
+
+    public function test_ping_event_is_acknowledged_without_deploying(): void
+    {
+        $launcher = $this->fakeLauncher();
+
+        $this->send(['zen' => 'hi'], event: 'ping')
+            ->assertOk()
+            ->assertJson(['message' => 'pong']);
+
+        $this->assertFalse($launcher->launched);
+    }
+
+    public function test_push_to_a_non_configured_branch_is_ignored(): void
+    {
+        config(['deployer.webhook_branch' => 'production']);
+        $launcher = $this->fakeLauncher();
+
+        $this->send(['ref' => 'refs/heads/main'])->assertOk();
+
+        $this->assertFalse($launcher->launched);
+    }
+
+    public function test_webhook_is_disabled_when_no_secret_is_set(): void
+    {
+        config(['deployer.github_webhook_secret' => null]);
+        $launcher = $this->fakeLauncher();
+
+        $this->send(['ref' => 'refs/heads/main'])->assertNotFound();
+
+        $this->assertFalse($launcher->launched);
+    }
+}


### PR DESCRIPTION
## Summary
Adds the webhook resolver from issue #1: a GitHub push triggers a deploy.

- `POST /api/webhooks/github` verifies the **`X-Hub-Signature-256` HMAC** against `DEPLOYER_GITHUB_WEBHOOK_SECRET` (no Sanctum token).
- Deploys the **pushed branch**; restrict to one branch with `DEPLOYER_WEBHOOK_BRANCH`.
- `ping` events are acknowledged; the endpoint is **404 until a secret is set**.
- Reuses `DeployLauncher::trigger()` (shared with the dashboard and API).

## Setup
GitHub → repo → Settings → Webhooks → content type `application/json`, the secret, *push* event.

## Verification
- Feature tests: valid push → 202 + branch deployed, bad signature → 401, ping → pong, non-matching branch ignored, disabled without secret → 404.
- 86 tests pass; `pint --test` clean.

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)